### PR TITLE
Use {v,l}apply in .as_vector_spectra_data

### DIFF
--- a/R/MsBackendDataFrame-functions.R
+++ b/R/MsBackendDataFrame-functions.R
@@ -204,10 +204,8 @@ MsBackendDataFrame <- function() {
 #'
 #' @noRd
 .as_vector_spectra_data <- function(x) {
-    cols <- colnames(x)[vapply(x, is, logical(1), "Rle")]
-    for (col in cols) {
-        x[[col]] <- as.vector(x[[col]])
-    }
+    isRle <- vapply(x, is, logical(1L), "Rle")
+    x[isRle] <- lapply(x[isRle], as.vector)
     x
 }
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/rformassspectrometry/Spectra/pull/31/files#r291992185

I wanted to avoid the index by `colnames` because this could slow things down. This PR uses `logical` indices with `{v,l}apply`. If there is at least one `Rle` column it is equal to/faster than the original approach. If there is not any `Rle` column it is more than 10x slower. So please feel free to merge or close this PR.
The the benchmark below (`.as_vector_spectra_data2` is the version implemented by this PR):

```r
library("microbenchmark")
library("S4Vectors")

.as_vector_spectra_data <- function(x) {
    cols <- colnames(x)[vapply(x, is, logical(1), "Rle")]
    for (col in cols) {
        x[[col]] <- as.vector(x[[col]])
    }
    x
}

.as_vector_spectra_data2 <- function(x) {
    isRle <- vapply(x, is, logical(1L), "Rle")
    x[isRle] <- lapply(x[isRle], as.vector)
    x
}

.as_vector_spectra_data3 <- function(x) {
    x[] <- lapply(x, function(xx) {
        if (is(xx, "Rle"))
            as.vector(xx)
        else
            xx
    })
    x
}

.as_vector_spectra_data4 <- function(x) {
    x[] <- lapply(x, as.vector)
    x
}

l <- lapply(1:100, rep, 100)
set.seed(2019)
i <- sample(100, 30)
l[i] <- lapply(l[i], Rle)
names(l) <- 1:100
d <- DataFrame(l)

all.equal(.as_vector_spectra_data(d), .as_vector_spectra_data2(d))
# [1] TRUE
all.equal(.as_vector_spectra_data(d), .as_vector_spectra_data3(d))
# [1] TRUE
all.equal(.as_vector_spectra_data(d), .as_vector_spectra_data4(d))
# [1] TRUE

microbenchmark(.as_vector_spectra_data(d), .as_vector_spectra_data2(d), .as_vector_spectra_data3(d), .as_vector_spectra_data4(d), times=10)
# Unit: milliseconds
#                         expr       min        lq      mean    median        uq
#   .as_vector_spectra_data(d) 247.55807 255.92178 276.12177 263.10411 283.29479
#  .as_vector_spectra_data2(d)  22.82122  23.50654  25.99010  25.44281  27.92109
#  .as_vector_spectra_data3(d)  52.85705  55.99283  64.49131  58.70141  81.58856
#  .as_vector_spectra_data4(d)  53.18697  55.74360  60.36532  56.31801  62.56408
#        max neval
#  334.11093    10
#   31.35830    10
#   82.72223    10
#   78.72177    10

l <- lapply(1:100, rep, 100)
l <- lapply(l, Rle)
names(l) <- 1:100
d <- DataFrame(l)
microbenchmark(.as_vector_spectra_data(d), .as_vector_spectra_data2(d), .as_vector_spectra_data3(d), .as_vector_spectra_data4(d), times=10)
# Unit: milliseconds
#                         expr       min         lq       mean     median
#   .as_vector_spectra_data(d) 957.89996 1005.21395 1026.53157 1018.56665
#  .as_vector_spectra_data2(d)  57.50140   58.23596   64.85076   58.94504
#  .as_vector_spectra_data3(d)  54.56560   55.05869   59.44750   56.90377
#  .as_vector_spectra_data4(d)  53.91237   54.78821   62.18958   56.04800
#          uq        max neval
#  1026.77254 1152.27277    10
#    65.97199   96.44167    10
#    57.11931   82.03208    10
#    64.15344   84.84225    10

l <- lapply(1:100, rep, 100)
l[[1]] <- Rle(l[[1]])
names(l) <- 1:100
d <- DataFrame(l)
microbenchmark(.as_vector_spectra_data(d), .as_vector_spectra_data2(d), .as_vector_spectra_data3(d), .as_vector_spectra_data4(d), times=10)
# Unit: milliseconds
#                         expr       min        lq      mean    median        uq
#   .as_vector_spectra_data(d)  7.314734  7.702832  8.454599  8.247011  9.556838
#  .as_vector_spectra_data2(d)  8.547811  8.709039  9.690174  8.988449 10.366771
#  .as_vector_spectra_data3(d) 53.225229 54.795238 59.747982 55.513488 61.524841
#  .as_vector_spectra_data4(d) 52.460907 53.169609 64.248581 53.780689 68.550386
#        max neval
#    9.63382    10
#   13.81606    10
#   80.78159    10
#  116.89315    10

l <- lapply(1:100, rep, 100)
names(l) <- 1:100
d <- DataFrame(l)
microbenchmark(.as_vector_spectra_data(d), .as_vector_spectra_data2(d), .as_vector_spectra_data3(d), .as_vector_spectra_data4(d), times=10)
# Unit: microseconds
#                         expr       min        lq       mean     median
#   .as_vector_spectra_data(d)   585.995   591.132   639.0757   619.5635
#  .as_vector_spectra_data2(d)  5606.151  5684.878  6783.2049  6062.2640
#  .as_vector_spectra_data3(d) 53679.004 54770.416 67367.7834 61678.8125
#  .as_vector_spectra_data4(d) 52636.948 53807.715 58249.8699 55085.8830
#         uq        max neval
#    659.367    762.805    10
#   6439.986  13125.822    10
#  71083.747 104187.940    10
#  56011.067  83982.908    10
```