### PR TITLE
.rbind_fill doesn't work if the first DataFrame doesn't contain a SimpleList but the second one

### DIFF
--- a/R/functions-util.R
+++ b/R/functions-util.R
@@ -213,45 +213,40 @@ utils.enableNeighbours <- function(x) {
 #'
 #' @return The merged object.
 #'
-#' @author Johannes Rainer
+#' @author Johannes Rainer, Sebastian Gibb
 #'
 #' @noRd
 .rbind_fill <- function(...) {
-    dots <- list(...)
-    cols_class <- lapply(dots, function(z) {
-        if (is.matrix(z)) {
-            res <- rep(class(z[, 1]), ncol(z))
-            names(res) <- colnames(z)
-        }
-        else res <- vapply(z, class, character(1))
-        res
-    })
-    cols_class <- unlist(cols_class)
-    cols_names <- unique(names(cols_class))
-    cols_class <- cols_class[cols_names]
-    res <- lapply(dots, function(z) {
-        cnz <- colnames(z)
-        rnz <- nrow(z)
-        is_matrix <- is.matrix(z)
-        mis_col <- setdiff(cols_names, cnz)
-        for (mc in mis_col) {
-            mc_class <- cols_class[mc]
-            if (mc_class == "factor")
-                z <- cbind(z, as.factor(NA))
-            else {
-                ## If we have a data.frame or DataFrame using cbind can result
-                ## in unwanted results if one of the columns is a S4class such
-                ## as SimpleList.
-                if (is_matrix)
-                    z <- cbind(z, as(NA, mc_class))
-                else
-                    z[[ncol(z) + 1]] <- as(rep(NA, rnz), mc_class)
-            }
-        }
-        colnames(z) <- c(cnz, mis_col)
-        z[, cols_names]
-    })
-    do.call(rbind, res)
+    l <- list(...)
+
+    if (length(l) == 1L)
+        l <- l[[1L]]
+
+    cl <- vapply(l, class, character(1L))
+
+    stopifnot(all(cl %in% c("matrix", "data.frame", "DataFrame")))
+
+    ## convert matrix to data.frame for easier and equal subsetting and class
+    ## determination
+    isMatrix <- cl == "matrix"
+    l[isMatrix] <- lapply(l[isMatrix], as.data.frame)
+
+    allcl <- unlist(lapply(l, vapply, class, character(1L)))
+    allnms <- unique(names(allcl))
+    allcl <- allcl[allnms]
+
+    for (i in seq(along=l)) {
+        diffcn <- setdiff(allnms, names(l[[i]]))
+        if (length(diffcn))
+            l[[i]][, diffcn] <- lapply(allcl[diffcn], as, object=NA_real_)
+    }
+    r <- do.call(rbind, l)
+
+    ## if we had just matrices as input we need to convert our temporary
+    ## data.frame back to a matrix
+    if (all(isMatrix))
+        r <- as.matrix(r)
+    r
 }
 
 .logging <- function(x, ...) {

--- a/tests/testthat/test_functions-util.R
+++ b/tests/testthat/test_functions-util.R
@@ -162,9 +162,19 @@ test_that(".rbind_fill works", {
     expect_identical(res$b, c(rep(FALSE, nrow(a)), rep(TRUE, nrow(b)), rep(NA, 5)))
 
     ## DataFrame containing SimpleList.
-    a$mz <- SimpleList(1:3, 1:4, 1:2, 1:3)
+    a$mz <- NumericList(1:3, 1:4, 1:2, 1:3)
     res <- .rbind_fill(a, b)
-    expect_true(is(res$mz, "SimpleList"))
+    expect_true(is(res$mz, "NumericList"))
     expect_true(all(unlist(is.na(res$mz[5:8]))))
-    expect_true(is.logical(res$mz[[5]]))
+    expect_true(is.na(res$mz[[5]]))
+
+    ## If the first DataFrame doesn't contain a SimpleList but the second one
+    res <- DataFrame(d = c(1L:4L, rep(NA_real_, 4L)),
+                     b = rep(c(TRUE, FALSE), each = 4L),
+                     e = Rle(1:2, 4),
+                     a = c(rep(NA_real_, 4L), 1L:4L),
+                     c = c(rep(NA_character_, 4L), letters[1L:4L]),
+                     mz = NumericList(NA_real_, NA_real_, NA_real_, NA_real_,
+                                      1:3, 1:4, 1:2, 1:3))
+    expect_equal(.rbind_fill(b, a), res)
 })


### PR DESCRIPTION
While thinking about the `.rbind_fill` implementation I found that the old one just works with `SimpleList` or `NumericList` if it is present in the first `DataFrame` (given as first argument).

```r
library("S4Vectors")
library("microbenchmark")

.rbind_fill <- function(...) {
    dots <- list(...)
    cols_class <- lapply(dots, function(z) {
        if (is.matrix(z)) {
            res <- rep(class(z[, 1]), ncol(z))
            names(res) <- colnames(z)
        }
        else res <- vapply(z, class, character(1))
        res
    })
    cols_class <- unlist(cols_class)
    cols_names <- unique(names(cols_class))
    cols_class <- cols_class[cols_names]
    res <- lapply(dots, function(z) {
        cnz <- colnames(z)
        rnz <- nrow(z)
        is_matrix <- is.matrix(z)
        mis_col <- setdiff(cols_names, cnz)
        for (mc in mis_col) {
            mc_class <- cols_class[mc]
            if (mc_class == "factor")
                z <- cbind(z, as.factor(NA))
            else {
                ## If we have a data.frame or DataFrame using cbind can result
                ## in unwanted results if one of the columns is a S4class such
                ## as SimpleList.
                if (is_matrix)
                    z <- cbind(z, as(NA, mc_class))
                else
                    z[[ncol(z) + 1]] <- as(rep(NA, rnz), mc_class)
            }
        }
        colnames(z) <- c(cnz, mis_col)
        z[, cols_names]
    })
    do.call(rbind, res)
}

.rbind_fill2 <- function(...) {
    l <- list(...)

    if (length(l) == 1L)
        l <- l[[1L]]

    cl <- vapply(l, class, character(1L))

    stopifnot(all(cl %in% c("matrix", "data.frame", "DataFrame")))

    ## convert matrix to data.frame for easier and equal subsetting and class
    ## determination
    isMatrix <- cl == "matrix"
    l[isMatrix] <- lapply(l[isMatrix], as.data.frame)

    allcl <- unlist(lapply(l, vapply, class, character(1L)))
    allnms <- unique(names(allcl))
    allcl <- allcl[allnms]

    for (i in seq(along=l)) {
        diffcn <- setdiff(allnms, names(l[[i]]))
        if (length(diffcn))
            l[[i]][, diffcn] <- lapply(allcl[diffcn], as, object=NA_real_)
    }
    r <- do.call(rbind, l)

    ## if we had just matrices as input we need to convert our temporary
    ## data.frame back to a matrix
    if (all(isMatrix))
        r <- as.matrix(r)
    r
}

m <- matrix(1:10, nrow=2, dimnames=list(c(), LETTERS[1:5]))
d <- data.frame(FOO=LETTERS[1:20], bar=factor(1:20), stringsAsFactors=FALSE)
DF <- DataFrame(FOO=LETTERS[1:2], BAR=SimpleList(a=1:2, b=3:5), bar=factor(22:23))

.rbind_fill(m, DF)
# Error: C stack usage  7973360 is too close to the limit
.rbind_fill(DF, m)
# DataFrame with 4 rows and 8 columns
#      FOO    BAR      bar      A      B      C      D      E
#   <list> <List> <factor> <list> <list> <list> <list> <list>
# 1      A    1,2       22     NA     NA     NA     NA     NA
# 2      B  3,4,5       23     NA     NA     NA     NA     NA
# 3     NA     NA       NA      1      3      5      7      9
# 4     NA     NA       NA      2      4      6      8     10

.rbind_fill2(m, DF)
# DataFrame with 4 rows and 8 columns
#           A         B         C         D         E         FOO    BAR      bar
#   <integer> <integer> <integer> <integer> <integer> <character> <List> <factor>
# 1         1         3         5         7         9          NA     NA       NA
# 2         2         4         6         8        10          NA     NA       NA
# 3        NA        NA        NA        NA        NA           A    1,2       22
# 4        NA        NA        NA        NA        NA           B  3,4,5       23
.rbind_fill2(DF, m)
# DataFrame with 4 rows and 8 columns
#           FOO    BAR      bar         A         B         C         D         E
#   <character> <List> <factor> <integer> <integer> <integer> <integer> <integer>
# 1           A    1,2       22        NA        NA        NA        NA        NA
# 2           B  3,4,5       23        NA        NA        NA        NA        NA
# 3          NA     NA       NA         1         3         5         7         9
# 4          NA     NA       NA         2         4         6         8        10

microbenchmark(.rbind_fill(m, d), .rbind_fill2(m, d))
# Unit: milliseconds
#                expr      min       lq     mean   median       uq      max neval
#   .rbind_fill(m, d) 1.561392 1.597212 1.752884 1.631050 1.705370 3.456680   100
#  .rbind_fill2(m, d) 1.337109 1.390791 1.523079 1.437449 1.490379 3.348146   100

microbenchmark(.rbind_fill(DF, m), .rbind_fill2(DF, m))
# Unit: milliseconds
#                 expr      min       lq     mean   median       uq      max
#   .rbind_fill(DF, m) 17.77343 18.42385 21.24111 19.78599 23.78747 33.08599
#  .rbind_fill2(DF, m) 17.21027 17.89975 21.00608 19.19728 23.78440 32.20624
#  neval
#    100
#    100
```