### PR TITLE
refactor: changes addressing performance bottlenecks

### DIFF
--- a/R/MsBackendMzR-functions.R
+++ b/R/MsBackendMzR-functions.R
@@ -15,6 +15,8 @@ MsBackendMzR <- function() {
 #'
 #' @author Johannes Rainer
 #'
+#' @importFrom MsCoreUtils vapply1l
+#'
 #' @return `DataFrame` with the header.
 #'
 #' @noRd
@@ -38,7 +40,9 @@ MsBackendMzR <- function() {
     hdr$isolationWindowUpperOffset <- NULL
     hdr$isolationWindowLowerOffset <- NULL
     ## Remove core spectra variables that contain only `NA`
-    S4Vectors::DataFrame(hdr)
+    S4Vectors::DataFrame(hdr[, !(vapply1l(hdr, function(z) all(is.na(z))) &
+                                 colnames(hdr) %in% names(.SPECTRA_DATA_COLUMNS))
+                             ])
 }
 
 #' Read peaks from a single mzML file.

--- a/R/Spectra-functions.R
+++ b/R/Spectra-functions.R
@@ -95,22 +95,20 @@ addProcessing <- function(object, FUN, ...) {
     ## Question whether we would use a slim version of the backend, i.e.
     ## reduce it to certain columns/spectra variables.
     res <- bplapply(split(object@backend, f), function(z, queue) {
-        .apply_processing_queue(peaks(z), msLevel(z), centroided(z),
-                                queue = queue)
+        .apply_processing_queue(peaks(z), msLevel(z),
+                                centroided(z), queue = queue)
     }, queue = pqueue, BPPARAM = BPPARAM)
     unsplit(res, f = f, drop = TRUE)
-    ## unlist(res, recursive = FALSE, use.names = FALSE)
 }
 
 #' @title Apply a function to a Spectra of length 1
 #'
 #' @description
 #'
-#' Utility function to apply any given function to a `Spectra` of length 1. If
-#' `length(x) > 1` the function splits `x` and calls itself with in a `lapply`
-#' call. The function `FUN` can expect to get a `Spectra` object of length 1
-#' and can access all of it's variables through the accessor methods or the `$`
-#' operator.
+#' Utility function to apply any given function to a `Spectra` of length 1 (or
+#' to chunks of the data defined by parameter `f`). The function `FUN` can
+#' expect to get a `Spectra` object of length 1 (or larger) and can access all
+#' of it's variables through the accessor methods or the `$` operator.
 #'
 #' @note
 #'
@@ -126,6 +124,9 @@ addProcessing <- function(object, FUN, ...) {
 #'
 #' @param FUN `function` to be applied to each spectrum.
 #'
+#' @param f factor to split `x` into chunks for parallel processing. Defaults
+#'     to splitting `x` by individual spectrum.
+#'
 #' @param ... Additional parameters for `FUN`.
 #'
 #' @param BPPARAM Optional settings for `BiocParallel`-based parallel
@@ -138,8 +139,9 @@ addProcessing <- function(object, FUN, ...) {
 #' @importFrom BiocParallel SerialParam
 #'
 #' @noRd
-.lapply <- function(x, FUN = identity, ..., BPPARAM = SerialParam()) {
-    res <- bplapply(split(x, seq_along(x)), FUN = FUN, ..., BPPARAM = BPPARAM)
+.lapply <- function(x, FUN = identity, f = seq_along(x), ...,
+                    BPPARAM = SerialParam()) {
+    res <- bplapply(split(x, f), FUN = FUN, ..., BPPARAM = BPPARAM)
     names(res) <- spectraNames(x)
     res
 }

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -676,8 +676,9 @@ NULL
 #' intensity(res)[[1]]
 #' intensity(res)[[2]]
 #'
-#' ## Second spectrum is now empty:
-#' isEmpty(res)
+#' ## Lengths of spectra is now different
+#' lengths(mz(res))
+#' lengths(mz(data))
 #'
 #' ## Compare spectra: comparing spectra 2 and 3 against spectra 10:20 using
 #' ## Pearson correlation and using all pairwise non-missing intensities
@@ -932,8 +933,10 @@ setMethod("dataStorage", "Spectra", function(object) dataStorage(object@backend)
 
 #' @rdname Spectra
 setMethod("intensity", "Spectra", function(object, ...) {
-    NumericList(lapply(.peaksapply(object, ...), function(z) z[, 2]),
-                compress = FALSE)
+    if (length(object@processingQueue))
+        NumericList(.peaksapply(object, FUN = function(z, ...) z[, 2], ...),
+                    compress = FALSE)
+    else intensity(object@backend) # Disables also parallel proc. (issue #44)
 })
 
 #' @rdname Spectra
@@ -1013,8 +1016,10 @@ setMethod("msLevel", "Spectra", function(object) msLevel(object@backend))
 
 #' @rdname Spectra
 setMethod("mz", "Spectra", function(object, ...) {
-    NumericList(lapply(.peaksapply(object, ...), function(z) z[, 1]),
-                compress = FALSE)
+    if (length(object@processingQueue))
+        NumericList(.peaksapply(object, FUN = function(z, ...) z[, 1], ...),
+                    compress = FALSE)
+    else mz(object@backend) # Disables also parallel processing (issue #44)
 })
 
 #' @rdname Spectra

--- a/man/MsBackend.Rd
+++ b/man/MsBackend.Rd
@@ -480,7 +480,7 @@ the spectra in \code{object}.
 \item \code{spectraVariables}: returns a \code{character} vector with the
 available spectra variables (columns, fields or attributes)
 available in \code{object}.
-\item \code{split}: split the backend into a \code{list} of backends (depending on
+\item \code{split}: splits the backend into a \code{list} of backends (depending on
 parameter \code{f}). The default method for \code{MsBackend} uses \code{\link[=split.default]{split.default()}},
 thus backends extending \code{MsBackend} don't necessarily need to implement
 this method.

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -863,8 +863,9 @@ res <- clean(res, all = TRUE)
 intensity(res)[[1]]
 intensity(res)[[2]]
 
-## Second spectrum is now empty:
-isEmpty(res)
+## Lengths of spectra is now different
+lengths(mz(res))
+lengths(mz(data))
 
 ## Compare spectra: comparing spectra 2 and 3 against spectra 10:20 using
 ## Pearson correlation and using all pairwise non-missing intensities


### PR DESCRIPTION
- `mz,Spectra` and `intensity,Spectra` avoid parallel processing. This significantly improves performance on in memory backends (issue #44).
- Avoid import of core spectra variables with only `NA` in `MsBackendMzR` (issue #67).
