### PR TITLE
refactor: mz and intensity aren't part of the default spectraVariables anymore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 0.4.1
+Version: 0.4.2
 Description: The Spectra package defines a efficient infrastructure
    for storing and handling for raw mass spectrometry spectra.
 Authors@R: c(person(given = "Laurent", family = "Gatto",

--- a/R/MsBackendDataFrame-functions.R
+++ b/R/MsBackendDataFrame-functions.R
@@ -84,8 +84,6 @@ NULL
     rtime = "numeric",
     acquisitionNum = "integer",
     scanIndex = "integer",
-    mz = "NumericList",
-    intensity = "NumericList",
     dataStorage = "character",
     dataOrigin = "character",
     centroided = "logical",


### PR DESCRIPTION
This PR addresses #92. The `mz` and `intensity` variables aren't part of the default `spectraVariables` any more and hence won't populate the `spectraData`, making it slow to access and big.

This PR only affects the on disk backends and not the in memory DataFrame backend, because for the latter, `mz` and `intensity` are already part of the DataFrame (and this aren't added). 