### PR TITLE
fix: support import of mzML files with different header columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 0.5.2
+Version: 0.5.3
 Description: The Spectra package defines a efficient infrastructure
    for storing and handling for raw mass spectrometry spectra.
 Authors@R: c(person(given = "Laurent", family = "Gatto",
@@ -25,7 +25,7 @@ Depends:
 Imports:
     methods,
     IRanges,
-    MsCoreUtils (>= 1.1.1),
+    MsCoreUtils (>= 1.1.4),
     BiocGenerics
 Suggests:
     testthat,

--- a/R/MsBackendMzR.R
+++ b/R/MsBackendMzR.R
@@ -36,6 +36,8 @@ setValidity("MsBackendMzR", function(object) {
 #'
 #' @importFrom methods callNextMethod
 #'
+#' @importFrom MsCoreUtils rbindFill
+#'
 #' @importMethodsFrom BiocParallel bpmapply
 #'
 #' @importFrom BiocParallel bpparam
@@ -52,7 +54,7 @@ setMethod("backendInitialize", "MsBackendMzR",
               if (length(msg))
                   stop(msg)
               spectraData <- do.call(
-                  rbind, bplapply(files,
+                  rbindFill, bplapply(files,
                                   FUN = function(fl) {
                                       cbind(Spectra:::.mzR_header(fl),
                                             dataStorage = fl)


### PR DESCRIPTION
- This fixes issue #82 by using `rbindFill` instead of `rbind` in combining the
  header of the individual mzML files into the final `DataFrame`.
- Note that this will also require `MsCoreUtils` 1.1.4 that fixes an issue in `rbindFill` if only a single `DataFrame` is passed.