### PR TITLE
Add support for user-provided function in filterIntensity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 0.99.5
+Version: 0.99.6
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Spectra 0.99
 
+## Changes in 0.99.6
+
+- Support `intensity` in `filterIntensity` method to be a function to enable
+  peak intensity-based filtering of spectra (issue
+  [#126](https://github.com/rformassspectrometry/Spectra/issues/126)).
+
 ## Changes in 0.99.5
 
 - Add `filterMzRange` and `filterMzValues` to filter spectra based on an m/z

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -414,7 +414,11 @@ NULL
 #'   is *simplified* to a `numeric` if length of `x` or `y` is one.
 #'
 #' - `filterIntensity`: filters each spectrum keeping only peaks with
-#'   intensities that are within the provided range (parameter `intensity`). To
+#'   intensities that are within the provided range or match the criteria of
+#'   the provided function. For the former, parameter `intensity` has to be a
+#'   `numeric` defining the intensity range, for the latter a `function` that
+#'   takes the intensity values of the spectrum and returns a `logical` whether
+#'   the peak should be retained or not (see examples below for details). To
 #'   remove only peaks with intensities below a certain threshold, say 100, use
 #'   `intensity = c(100, Inf)`. Note: also a single value can be passed with
 #'   the `intensity` parameter in which case an upper limit of `Inf` is used.
@@ -548,8 +552,10 @@ NULL
 #'
 #' @param intensity For `filterIntensity`: `numeric` of length 1 or 2 defining
 #'     either the lower or the lower and upper intensity limit for the
-#'     filtering. Defaults to `intensity = c(0, Inf)` thus only peaks with `NA`
-#'     intensity are removed.
+#'     filtering, or a `function` that takes the intensities as input and
+#'     returns a `logical` (same length then peaks in the spectrum) whether the
+#'     peak should be retained or not. Defaults to `intensity = c(0, Inf)` thus
+#'     only peaks with `NA` intensity are removed.
 #'
 #' @param k For `pickPeaks`: `integer(1)`, number of values left and right of
 #'  the peak that should be considered in the weighted mean calculation.
@@ -840,6 +846,17 @@ NULL
 #' ## Lengths of spectra is now different
 #' lengths(mz(res))
 #' lengths(mz(data))
+#'
+#' ## In addition it is possible to pass a function to `filterIntensity`: in
+#' ## the example below we want to keep only peaks that have an intensity which
+#' ## is larger than one third of the maximal peak intensity in that spectrum.
+#' keep_peaks <- function(x) {
+#'     x > max(x, na.rm = TRUE) / 3
+#' }
+#' res2 <- filterIntensity(data, intensity = keep_peaks)
+#' intensity(res2)[[1L]]
+#' intensity(data)[[1L]]
+#'
 #'
 #' ## Since data manipulation operations are by default not directly applied to
 #' ## the data but only added to the internal lazy evaluation queue, it is also
@@ -1519,20 +1536,34 @@ setMethod("filterIntensity", "Spectra",
                    msLevel. = unique(msLevel(object))) {
               if (!.check_ms_level(object, msLevel.))
                   return(object)
-              if (length(intensity) == 1)
-                  intensity <- c(intensity, Inf)
-              if (length(intensity) != 2)
-                  stop("'intensity' should be of length specifying a lower ",
-                       "intensity limit or of length two defining a lower and",
-                       " upper limit.")
-              object <- addProcessing(object, .peaks_filter_intensity,
-                                      intensity = intensity,
-                                      msLevel = msLevel.)
-              object@processing <- .logging(
-                  object@processing, "Remove peaks with intensities outside [",
-                  intensity[1], ", ", intensity[2],
-                  "] in spectra of MS level(s) ",
-                  paste0(msLevel., collapse = ", "), ".")
+              if (is.numeric(intensity)) {
+                  if (length(intensity) == 1)
+                      intensity <- c(intensity, Inf)
+                  if (length(intensity) != 2)
+                      stop("'intensity' should be of length specifying a ",
+                           "lower intensity limit or of length two defining ",
+                           "a lower and upper limit.")
+                  object <- addProcessing(object, .peaks_filter_intensity,
+                                          intensity = intensity,
+                                          msLevel = msLevel.)
+                  object@processing <- .logging(
+                      object@processing, "Remove peaks with intensities ",
+                      "outside [", intensity[1], ", ", intensity[2],
+                      "] in spectra of MS level(s) ",
+                      paste0(msLevel., collapse = ", "), ".")
+              } else {
+                  if (is.function(intensity)) {
+                      object <- addProcessing(
+                          object, .peaks_filter_intensity_function,
+                          intensity = intensity, msLevel = msLevel.)
+                      object@processing <- .logging(
+                          object@processing, "Remove peaks based on their ",
+                          "intensities and a user-provided function ",
+                          "in spectra of MS level(s) ",
+                          paste0(msLevel., collapse = ", "), ".")
+                  }
+                  else stop("'intensity' has to be numeric or a function")
+              }
               object
           })
 

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -1054,7 +1054,8 @@ setMethod("setBackend", c("Spectra", "MsBackend"),
               bknds <- bplapply(split(object@backend, f = f), function(z, ...) {
                   backendInitialize(backend,
                                     data = spectraData(z),
-                                    ...)
+                                    ...,
+                                    BPPARAM = SerialParam())
               }, ..., BPPARAM = BPPARAM)
               bknds <- backendMerge(bknds)
               ## That below ensures the backend is returned in its original

--- a/R/peaks-functions.R
+++ b/R/peaks-functions.R
@@ -92,6 +92,31 @@ NULL
 
 #' @description
 #'
+#' Filter peaks with an intensity-based function.
+#'
+#' @inheritParam .peaks_remove
+#'
+#' @param intensity function which takes intensities as first parameter and
+#'     returns a `logical` of length equal to the number of peaks in the
+#'     spectrum.
+#'
+#' @author Johannes Rainer
+#'
+#' @noRd
+.peaks_filter_intensity_function <- function(x, spectrumMsLevel, intensity,
+                                             msLevel = spectrumMsLevel, ...) {
+    if (!spectrumMsLevel %in% msLevel || !length(x))
+        return(x)
+    keep <- intensity(x[, "intensity"])
+    if (!is.logical(keep) || length(keep) != nrow(x))
+        stop("Error in filterIntensity: the provided function does not return ",
+             "a logical vector of length equal to the number of peaks.",
+             call. = FALSE)
+    x[which(keep), , drop = FALSE]
+}
+
+#' @description
+#'
 #' Filter the spectrum keeping only peaks that match the provided m/z value(s).
 #'
 #' @inheritParams .peaks_remove

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -460,8 +460,10 @@ only for spectra of selected \code{dataOrigin}.}
 
 \item{intensity}{For \code{filterIntensity}: \code{numeric} of length 1 or 2 defining
 either the lower or the lower and upper intensity limit for the
-filtering. Defaults to \code{intensity = c(0, Inf)} thus only peaks with \code{NA}
-intensity are removed.}
+filtering, or a \code{function} that takes the intensities as input and
+returns a \code{logical} (same length then peaks in the spectrum) whether the
+peak should be retained or not. Defaults to \code{intensity = c(0, Inf)} thus
+only peaks with \code{NA} intensity are removed.}
 
 \item{msLevel.}{\code{integer} defining the MS level(s) of the spectra to which
 the function should be applied (defaults to all MS levels of \code{object}.
@@ -886,7 +888,11 @@ equal \code{length(y)} (i.e. element in row 2 and column 3 is the result from
 the comparison of \code{x[2]} with \code{y[3]}). If \code{SIMPLIFY = TRUE} the \code{matrix}
 is \emph{simplified} to a \code{numeric} if length of \code{x} or \code{y} is one.
 \item \code{filterIntensity}: filters each spectrum keeping only peaks with
-intensities that are within the provided range (parameter \code{intensity}). To
+intensities that are within the provided range or match the criteria of
+the provided function. For the former, parameter \code{intensity} has to be a
+\code{numeric} defining the intensity range, for the latter a \code{function} that
+takes the intensity values of the spectrum and returns a \code{logical} whether
+the peak should be retained or not (see examples below for details). To
 remove only peaks with intensities below a certain threshold, say 100, use
 \code{intensity = c(100, Inf)}. Note: also a single value can be passed with
 the \code{intensity} parameter in which case an upper limit of \code{Inf} is used.
@@ -1124,6 +1130,17 @@ intensity(res)[[2]]
 ## Lengths of spectra is now different
 lengths(mz(res))
 lengths(mz(data))
+
+## In addition it is possible to pass a function to `filterIntensity`: in
+## the example below we want to keep only peaks that have an intensity which
+## is larger than one third of the maximal peak intensity in that spectrum.
+keep_peaks <- function(x) {
+    x > max(x, na.rm = TRUE) / 3
+}
+res2 <- filterIntensity(data, intensity = keep_peaks)
+intensity(res2)[[1L]]
+intensity(data)[[1L]]
+
 
 ## Since data manipulation operations are by default not directly applied to
 ## the data but only added to the internal lazy evaluation queue, it is also

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -969,6 +969,27 @@ test_that("filterIntensity,Spectra works", {
     expect_true(all(ints >= 500 & ints <= 9000))
 
     expect_error(filterIntensity(Spectra(sciex_mzr), c(1, 2, 3)), "limit")
+
+    ## With `intensity` being a function.
+    sps <- Spectra()
+    res <- filterIntensity(sps, intensity = function(x) x > mean(x))
+    expect_true(length(res@processingQueue) == 1)
+    expect_true(length(intensity(res)) == 0)
+
+    expect_error(filterIntensity(sps, intensity = TRUE), "numeric or a fun")
+
+    df <- DataFrame(msLevel = c(1L, 2L), fromFile = 1L)
+    df$mz <- list(1:4, 1:5)
+    df$intensity <- list(1:4, 1:5)
+    sps <- Spectra(df)
+
+    res <- filterIntensity(sps, intensity = function(x) x > max(x)/2)
+    expect_equal(intensity(res)[[1L]], c(3, 4))
+    expect_equal(intensity(res)[[2L]], c(3, 4, 5))
+    res <- filterIntensity(sps, intensity = function(x) x > max(x)/2,
+                           msLevel = 1L)
+    expect_equal(intensity(res)[[1L]], c(3, 4))
+    expect_equal(intensity(res)[[2L]], c(1, 2, 3, 4, 5))
 })
 
 test_that("compareSpectra works", {

--- a/tests/testthat/test_peaks-functions.R
+++ b/tests/testthat/test_peaks-functions.R
@@ -43,6 +43,30 @@ test_that(".peaks_filter_intensity works", {
     expect_equal(res[, 1], c(1, 3, 4, 5, 6, 14))
 })
 
+test_that(".peaks_filter_intensity_function works", {
+    ints <- c(5, 3, 12, 14.4, 13.3, 9, 3, 0, NA, 21, 89, 55, 33, 5, 2)
+    x <- cbind(mz = seq_along(ints), intensity = ints)
+    res <- .peaks_filter_intensity_function(
+        x, spectrumMsLevel = 1L, intensity = function(x) x > 0)
+    expect_equal(res[, 1], c(1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15))
+
+    res <- .peaks_filter_intensity_function(
+        x, spectrumMsLevel = 1L,
+        intensity = function(z) z > max(z, na.rm = TRUE) / 2)
+    expect_true(all(res[, "intensity"] > 89/2))
+
+    res <- .peaks_filter_intensity_function(x, spectrumMsLevel = 1L,
+                                            msLevel = 2L)
+    expect_equal(res, x)
+
+    expect_error(.peaks_filter_intensity_function(
+        x, spectrumMsLevel = 1L, function(x) FALSE),
+        "does not return a")
+    expect_error(.peaks_filter_intensity_function(
+        x, spectrumMsLevel = 1L, function(x) which(is.na(x))),
+        "does not return a")
+})
+
 test_that(".peaks_bin works", {
     int <- c(0, 1, 2, 3, 1, 0, 0, 0, 0, 1, 3, 10, 6, 2, 1, 0, 1, 2, 0,
              0, 1, 5, 10, 5, 1)

--- a/vignettes/Spectra.Rmd
+++ b/vignettes/Spectra.Rmd
@@ -417,6 +417,11 @@ sps_rep <- filterIntensity(sps_rep, intensity = c(0.1, Inf))
 intensity(sps_rep)
 ```
 
+The `filterIntensity` supports also a user-provided function to be passed with
+parameter `intensity` which would allow e.g. to remove peaks smaller than the
+median peak intensity of a spectrum. See examples in the `?filterIntensity` help
+page for details.
+
 Note that any data manipulations on `Spectra` objects are not immediately
 applied to the peak data. They are added to a so called *processing queue* which
 is applied each time peak data is accessed (with the `peaksData`, `mz` or


### PR DESCRIPTION
- `filterIntensity` supports a function with parameter `intensity` that allows to perform a peak intensity-based filtering (e.g. remove peaks that have an intensity smaller than 30% of the largest intensity in that spectrum).