### PR TITLE
fix: dropNaSpectraVariables no longer drops mz and intensity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 0.99.6
+Version: 0.99.7
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Spectra 0.99
 
+## Changes in 0.99.7
+
+- Fix problem in `dropNaSpectraVariables` that would also drop m/z and
+  intensity values for most backends (issue
+  [#138](https://github.com/rformassspectrometry/Spectra/issues/138).
+
 ## Changes in 0.99.6
 
 - Support `intensity` in `filterIntensity` method to be a function to enable

--- a/R/MsBackend.R
+++ b/R/MsBackend.R
@@ -340,14 +340,18 @@
 #' - `spectraData`, `spectraData<-`: gets or sets general spectrum
 #'   metadata (annotation, also called header).  `spectraData` returns
 #'   a `DataFrame`, `spectraData<-` expects a `DataFrame` with the same number
-#'   of rows as there are spectra in `object`.
+#'   of rows as there are spectra in `object`. Note that `spectraData` has to
+#'   return the full data, i.e. also the m/z and intensity values (as a `list`
+#'   or `SimpleList` in columns `"mz"` and `"intensity"`.
 #'
 #' - `spectraNames`: returns a `character` vector with the names of
 #'   the spectra in `object`.
 #'
 #' - `spectraVariables`: returns a `character` vector with the
 #'   available spectra variables (columns, fields or attributes)
-#'   available in `object`.
+#'   available in `object`. This should return **all** spectra variables which
+#'   are present in `object`, also `"mz"` and `"intensity"` (which are by
+#'   default not returned by the `spectraVariables,Spectra` method).
 #'
 #' - `split`: splits the backend into a `list` of backends (depending on
 #'   parameter `f`). The default method for `MsBackend` uses [split.default()],
@@ -693,10 +697,10 @@ setReplaceMethod("dataStorage", "MsBackend", function(object, value) {
 #' @rdname MsBackend
 setMethod("dropNaSpectraVariables", "MsBackend", function(object) {
     svs <- spectraVariables(object)
-    spd <- spectraData(object, columns = svs[!(svs %in% c("mz", "intensity"))])
+    svs <- svs[!(svs %in% c("mz", "intensity"))]
+    spd <- spectraData(object, columns = svs)
     keep <- !vapply1l(spd, function(z) all(is.na(z)))
-    spectraData(object) <- spd[, keep, drop = FALSE]
-    object
+    selectSpectraVariables(object, c(svs[keep], "mz", "intensity"))
 })
 
 #' @exportMethod filterAcquisitionNum

--- a/R/peaks-functions.R
+++ b/R/peaks-functions.R
@@ -94,7 +94,7 @@ NULL
 #'
 #' Filter peaks with an intensity-based function.
 #'
-#' @inheritParam .peaks_remove
+#' @inheritParams .peaks_remove
 #'
 #' @param intensity function which takes intensities as first parameter and
 #'     returns a `logical` of length equal to the number of peaks in the

--- a/man/MsBackend.Rd
+++ b/man/MsBackend.Rd
@@ -512,12 +512,16 @@ of length 1 or equal to the number of spectra in \code{object}.
 \item \code{spectraData}, \verb{spectraData<-}: gets or sets general spectrum
 metadata (annotation, also called header).  \code{spectraData} returns
 a \code{DataFrame}, \verb{spectraData<-} expects a \code{DataFrame} with the same number
-of rows as there are spectra in \code{object}.
+of rows as there are spectra in \code{object}. Note that \code{spectraData} has to
+return the full data, i.e. also the m/z and intensity values (as a \code{list}
+or \code{SimpleList} in columns \code{"mz"} and \code{"intensity"}.
 \item \code{spectraNames}: returns a \code{character} vector with the names of
 the spectra in \code{object}.
 \item \code{spectraVariables}: returns a \code{character} vector with the
 available spectra variables (columns, fields or attributes)
-available in \code{object}.
+available in \code{object}. This should return \strong{all} spectra variables which
+are present in \code{object}, also \code{"mz"} and \code{"intensity"} (which are by
+default not returned by the \verb{spectraVariables,Spectra} method).
 \item \code{split}: splits the backend into a \code{list} of backends (depending on
 parameter \code{f}). The default method for \code{MsBackend} uses \code{\link[=split.default]{split.default()}},
 thus backends extending \code{MsBackend} don't necessarily need to implement

--- a/tests/testthat/test_MsBackendDataFrame.R
+++ b/tests/testthat/test_MsBackendDataFrame.R
@@ -858,3 +858,17 @@ test_that("isCentroided,MsBackendDataFrame works", {
     msb <- backendInitialize(msb, test_df)
     expect_true(all(is.na(isCentroided(msb))))
 })
+
+test_that("dropNaSpectraVariables works with MsBackendDataFrame", {
+    b <- MsBackendDataFrame()
+    expect_true(length(dropNaSpectraVariables(b)) == 0)
+    b <- backendInitialize(b, test_df)
+    res <- dropNaSpectraVariables(b)
+    expect_equal(spectraVariables(b), spectraVariables(res))
+    expect_equal(mz(b), mz(res))
+    expect_equal(intensity(b), intensity(res))
+
+    b$other_col <- NA
+    res <- dropNaSpectraVariables(b)
+    expect_true(!any(spectraVariables(res) == "other_col"))
+})

--- a/tests/testthat/test_MsBackendHdf5Peaks.R
+++ b/tests/testthat/test_MsBackendHdf5Peaks.R
@@ -375,3 +375,10 @@ test_that("backendMerge,MsBackendHdf5Peaks works", {
     expect_true(validObject(be3))
     expect_error(mz(res))
 })
+
+test_that("dropNaSpectraVariables works with MsBackendHdf5", {
+    res <- dropNaSpectraVariables(sciex_hd5)
+    expect_equal(mz(res[1]), mz(sciex_hd5[1]))
+    expect_true(length(spectraVariables(res)) <
+                length(spectraVariables(sciex_hd5)))
+})

--- a/tests/testthat/test_MsBackendMzR.R
+++ b/tests/testthat/test_MsBackendMzR.R
@@ -542,3 +542,10 @@ test_that("export,MsBackendMzR works", {
     res <- Spectra(backendInitialize(MsBackendMzR(), fl))
     expect_equal(rtime(res), rtime(sps))
 })
+
+test_that("dropNaSpectraVariables works with MsBackendMzR", {
+    res <- dropNaSpectraVariables(sciex_mzr)
+    expect_equal(mz(res[1]), mz(sciex_mzr[1]))
+    expect_true(length(spectraVariables(res)) <
+                length(spectraVariables(sciex_mzr)))
+})

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1298,3 +1298,31 @@ test_that("filterMzValue,Spectra works", {
     expect_error(filterMzValues(sps, mz = c(56, 12), ppm = c(1, 2, 3)),
                  "length 1 or equal")
 })
+
+test_that("dropNaSpectraVariables works with MsBackendMzR", {
+    sps <- Spectra()
+    res <- dropNaSpectraVariables(sps)
+    expect_equal(spectraVariables(sps), spectraVariables(res))
+
+    sps <- Spectra(sciex_mzr)
+    res <- dropNaSpectraVariables(sps)
+    expect_equal(mz(res[1]), mz(sps[1]))
+    expect_true(length(spectraVariables(res)) <
+                length(spectraVariables(sps)))
+
+    df <- DataFrame(msLevel = c(1L, 1L), rtime = c(1.2, 1.3), centroided = TRUE)
+    df$mz <- list(1:10, 1:10)
+    df$intensity <- list(c(0, 0, 1, 6, 3, 0, 0, 9, 1, 0),
+                         c(9, 6, 0, 0, 3, 0, 0, 0, 3, 2))
+    sps <- Spectra(df)
+
+    res <- dropNaSpectraVariables(sps)
+    expect_equal(mz(res), mz(sps))
+    expect_equal(intensity(res), intensity(sps))
+    expect_equal(spectraVariables(res), spectraVariables(sps))
+
+    sps$other_col <- NA
+    res <- dropNaSpectraVariables(sps)
+    expect_equal(mz(res), mz(sps))
+    expect_true(length(spectraVariables(res)) < length(spectraVariables(sps)))
+})


### PR DESCRIPTION
- Fix `dropNaSpectraVariables` does no longer drop the `"mz"` and `"intensity"`
  columns (issue #138).
- Update also documentation of `spectraData,MsBackend` to clearly state it has
  to return also m/z and intensity values.