### PR TITLE
fix: ensure backend is changed in Spectra,character constructor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 0.99.8
+Version: 0.99.9
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Spectra 0.99
 
+## Changes in 0.99.9
+
+- Fix in `Spectra,character` constructor to ensure the backend is changed even
+  if `source` inherits from `backend` (issue
+  [#143](https://github.com/rformassspectrometry/Spectra/issues/143)).
+
 ## Changes in 0.99.8
 
 - `combineSpectra` applies data processing steps in the processing queue prior to

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -1056,7 +1056,7 @@ setMethod("Spectra", "character", function(object, processingQueue = list(),
     be <- backendInitialize(source, object, ..., BPPARAM = BPPARAM)
     sp <- new("Spectra", metadata = metadata, processingQueue = processingQueue,
               backend = be)
-    if (!is(source, class(backend)[1]))
+    if (class(source)[1] != class(backend)[1])
         setBackend(sp, backend, ..., BPPARAM = BPPARAM)
     else sp
 })


### PR DESCRIPTION
- Fix that the backend is changed even if the backend passed with `source`
  extends the backend specified with `backend` (issue #146).