### PR TITLE
refactor: replace Spectra,DataFrame by Spectra,ANY

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.1.2
+Version: 1.1.3
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
 # Spectra 1.1
 
+## Changes in 1.1.3
+
+- Implement a generic `Spectra,ANY` constructor replacing `Spectra,DataFrame`
+  and `Spectra,character`.
+
 ## Changes in 1.1.2
 
 - Fix problem in export to mzML files that failed for empty spectra (issue
   [#145](https://github.com/rformassspectrometry/Spectra/issues/145))
-
 
 ## Changes in 1.1.1
 

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -1045,15 +1045,6 @@ setMethod("show", "Spectra",
     })
 
 #' @rdname Spectra
-setMethod("Spectra", "DataFrame", function(object, processingQueue = list(),
-                                           metadata = list(), ...,
-                                           backend = MsBackendDataFrame(),
-                                           BPPARAM = bpparam()) {
-    new("Spectra", metadata = metadata, processingQueue = processingQueue,
-        backend = backendInitialize(backend, object, ..., BPPARAM = BPPARAM))
-})
-
-#' @rdname Spectra
 setMethod("Spectra", "missing", function(object, processingQueue = list(),
                                          metadata = list(), ...,
                                          backend = MsBackendDataFrame(),
@@ -1071,15 +1062,28 @@ setMethod("Spectra", "MsBackend", function(object, processingQueue = list(),
 })
 
 #' @rdname Spectra
+#'
+#' @importFrom methods callNextMethod
 setMethod("Spectra", "character", function(object, processingQueue = list(),
                                            metadata = list(),
                                            source = MsBackendMzR(),
                                            backend = source,
                                            ..., BPPARAM = bpparam()) {
-    be <- backendInitialize(source, object, ..., BPPARAM = BPPARAM)
+    callNextMethod(object = object, processingQueue = processingQueue,
+                   metadata = metadata, source = source, backend = backend,
+                   ..., BPPARAM = BPPARAM)
+})
+
+#' @rdname Spectra
+setMethod("Spectra", "ANY", function(object, processingQueue = list(),
+                                     metadata = list(),
+                                     source = MsBackendDataFrame(),
+                                     backend = source,
+                                     ..., BPPARAM = bpparam()) {
     sp <- new("Spectra", metadata = metadata, processingQueue = processingQueue,
-              backend = be)
-    if (class(source)[1] != class(backend)[1])
+              backend = backendInitialize(source, object, ...,
+                                          BPPARAM = BPPARAM))
+    if (class(source)[1L] != class(backend)[1L])
         setBackend(sp, backend, ..., BPPARAM = BPPARAM)
     else sp
 })

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -7,10 +7,10 @@
 \alias{Spectra}
 \alias{Spectra-class}
 \alias{[,Spectra-method}
-\alias{Spectra,DataFrame-method}
 \alias{Spectra,missing-method}
 \alias{Spectra,MsBackend-method}
 \alias{Spectra,character-method}
+\alias{Spectra,ANY-method}
 \alias{setBackend,Spectra,MsBackend-method}
 \alias{c,Spectra-method}
 \alias{split,Spectra,ANY-method}
@@ -97,15 +97,6 @@ combineSpectra(
   BPPARAM = bpparam()
 )
 
-\S4method{Spectra}{DataFrame}(
-  object,
-  processingQueue = list(),
-  metadata = list(),
-  ...,
-  backend = MsBackendDataFrame(),
-  BPPARAM = bpparam()
-)
-
 \S4method{Spectra}{missing}(
   object,
   processingQueue = list(),
@@ -128,6 +119,16 @@ combineSpectra(
   processingQueue = list(),
   metadata = list(),
   source = MsBackendMzR(),
+  backend = source,
+  ...,
+  BPPARAM = bpparam()
+)
+
+\S4method{Spectra}{ANY}(
+  object,
+  processingQueue = list(),
+  metadata = list(),
+  source = MsBackendDataFrame(),
   backend = source,
   ...,
   BPPARAM = bpparam()

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1,4 +1,4 @@
-test_that("Spectra,DataFrame works", {
+test_that("Spectra,ANY works", {
     df <- DataFrame()
     res <- Spectra(df)
     expect_true(validObject(res))
@@ -41,8 +41,9 @@ test_that("Spectra,character works", {
     expect_equal(unique(res@backend$dataStorage), sciex_file)
     expect_identical(rtime(res), rtime(sciex_mzr))
 
-    res_2 <- Spectra(sciex_file)
-    expect_true(is(res@backend, "MsBackendDataFrame"))
+    res_2 <- Spectra(sciex_file, source = MsBackendMzR(),
+                     backend = MsBackendDataFrame())
+    expect_true(is(res_2@backend, "MsBackendDataFrame"))
     expect_identical(rtime(res), rtime(res_2))
 
     show(res)


### PR DESCRIPTION
Implement a `Spectra,ANY` constructor method that *imports* data using the `source` backend (eventually converting to `backend` backend). This supports also to create a `Spectra` object based on a e.g. database connection, given that the `MsBackend` specified with `source` knows how to handle that (issue #152).

I think this will save us from unnecessary additional implementation of constructor methods, e.g. for `Spectra,DBIconnection` or similar.