### PR TITLE
Add support for arbitrary parameters in filterIntensity (issue #164)

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -138,8 +138,9 @@ jobs:
           brew uninstall curl
 
           ## required for ncdf4 - can not use the homebrew one because that uses GCC
-          curl -O http://mac.R-project.org/libs-4/netcdf-4.7.4-darwin.17-x86_64.tar.gz
+          curl -O https://mac.r-project.org/libs-4/netcdf-4.7.4-darwin.17-x86_64.tar.gz
           tar fvxz netcdf-4.7.4-darwin.17-x86_64.tar.gz -C /
+          rm netcdf-4.7.4-darwin.17-x86_64.tar.gz
 
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -137,8 +137,9 @@ jobs:
           ## Helps compile RCurl from source
           brew uninstall curl
 
-          ## required for ncdf4
-          ## brew install netcdf
+          ## required for ncdf4 - can not use the homebrew one because that uses GCC
+          curl -O http://mac.R-project.org/libs-4/netcdf-4.7.4-darwin.17-x86_64.tar.gz
+          tar fvxz netcdf-4.7.4-darwin.17-x86_64.tar.gz -C /
 
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -139,7 +139,7 @@ jobs:
 
           ## required for ncdf4 - can not use the homebrew one because that uses GCC
           curl -O https://mac.r-project.org/libs-4/netcdf-4.7.4-darwin.17-x86_64.tar.gz
-          tar fvxz netcdf-4.7.4-darwin.17-x86_64.tar.gz -C /
+          tar fvxz -m netcdf-4.7.4-darwin.17-x86_64.tar.gz -C /
           rm netcdf-4.7.4-darwin.17-x86_64.tar.gz
 
       - name: Install Windows system dependencies

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -138,7 +138,7 @@ jobs:
           brew uninstall curl
 
           ## required for ncdf4
-          brew install netcdf
+          ## brew install netcdf
 
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -139,7 +139,7 @@ jobs:
 
           ## required for ncdf4 - can not use the homebrew one because that uses GCC
           curl -O https://mac.r-project.org/libs-4/netcdf-4.7.4-darwin.17-x86_64.tar.gz
-          tar fvxz -m netcdf-4.7.4-darwin.17-x86_64.tar.gz -C /
+          tar fvxzm netcdf-4.7.4-darwin.17-x86_64.tar.gz -C /
           rm netcdf-4.7.4-darwin.17-x86_64.tar.gz
 
       - name: Install Windows system dependencies

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -137,6 +137,9 @@ jobs:
           ## Helps compile RCurl from source
           brew uninstall curl
 
+          ## required for ncdf4
+          brew install netcdf
+
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## Changes in 1.1.8
 
-- Nothing yet
+- `filterIntensity` supports passing of additional parameters to the used
+  filter function (issue
+  [164](https://github.com/rformassspectrometry/Spectra/issues/164)).
 
 ## Changes in 1.1.7
 

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -370,13 +370,13 @@ NULL
 #'    function allows to merge a `DataFrame` to the existing spectra
 #'    data. This function diverges from the [merge()] method in two
 #'    main ways:
-#'     - The `by.x` and `by.y` column names must be of length 1. 
+#'     - The `by.x` and `by.y` column names must be of length 1.
 #'     - If variable names are shared in `x` and `y`, the spectra
 #'       variables of `x` are not modified. It's only the `y`
 #'       variables that are appended the suffix defined in
 #'       `suffix.y`. This is to avoid modifying any core spectra
 #'       variables that would lead to an invalid object.
-#' 
+#'
 #' Several `Spectra` objects can be concatenated into a single object with the
 #' `c` function. Concatenation will fail if the processing queue of any of the
 #' `Spectra` objects is not empty or if different backends are used in the
@@ -463,7 +463,8 @@ NULL
 #'   the provided function. For the former, parameter `intensity` has to be a
 #'   `numeric` defining the intensity range, for the latter a `function` that
 #'   takes the intensity values of the spectrum and returns a `logical` whether
-#'   the peak should be retained or not (see examples below for details). To
+#'   the peak should be retained or not (see examples below for details) -
+#'   additional parameters to the function can be passed with `...`. To
 #'   remove only peaks with intensities below a certain threshold, say 100, use
 #'   `intensity = c(100, Inf)`. Note: also a single value can be passed with
 #'   the `intensity` parameter in which case an upper limit of `Inf` is used.
@@ -884,9 +885,9 @@ NULL
 #'                  var1 = rnorm(10),
 #'                  var2 = sample(letters, 10))
 #' spv
-#' 
+#'
 #' sciex2 <- joinSpectraData(sciex, spv, by.y = "spectrumId")
-#' 
+#'
 #' spectraVariables(sciex2)
 #' spectraData(sciex2)[1:13, c("spectrumId", "var1", "var2")]
 #'
@@ -918,13 +919,19 @@ NULL
 #' ## In addition it is possible to pass a function to `filterIntensity`: in
 #' ## the example below we want to keep only peaks that have an intensity which
 #' ## is larger than one third of the maximal peak intensity in that spectrum.
-#' keep_peaks <- function(x) {
-#'     x > max(x, na.rm = TRUE) / 3
+#' keep_peaks <- function(x, prop = 3) {
+#'     x > max(x, na.rm = TRUE) / prop
 #' }
 #' res2 <- filterIntensity(data, intensity = keep_peaks)
 #' intensity(res2)[[1L]]
 #' intensity(data)[[1L]]
 #'
+#' ## We can also change the proportion by simply passing the `prop` parameter
+#' ## to the function. To keep only peaks that have an intensity which is
+#' ## larger than half of the maximum intensity:
+#' res2 <- filterIntensity(data, intensity = keep_peaks, prop = 2)
+#' intensity(res2)[[1L]]
+#' intensity(data)[[1L]]
 #'
 #' ## Since data manipulation operations are by default not directly applied to
 #' ## the data but only added to the internal lazy evaluation queue, it is also
@@ -1647,7 +1654,7 @@ setMethod("filterDataStorage", "Spectra", function(object,
 #' @exportMethod filterIntensity
 setMethod("filterIntensity", "Spectra",
           function(object, intensity = c(0, Inf),
-                   msLevel. = unique(msLevel(object))) {
+                   msLevel. = unique(msLevel(object)), ...) {
               if (!.check_ms_level(object, msLevel.))
                   return(object)
               if (is.numeric(intensity)) {
@@ -1669,7 +1676,8 @@ setMethod("filterIntensity", "Spectra",
                   if (is.function(intensity)) {
                       object <- addProcessing(
                           object, .peaks_filter_intensity_function,
-                          intensity = intensity, msLevel = msLevel.)
+                          intfun = intensity, msLevel = msLevel.,
+                          args = list(...))
                       object@processing <- .logging(
                           object@processing, "Remove peaks based on their ",
                           "intensities and a user-provided function ",

--- a/R/peaks-functions.R
+++ b/R/peaks-functions.R
@@ -96,18 +96,19 @@ NULL
 #'
 #' @inheritParams .peaks_remove
 #'
-#' @param intensity function which takes intensities as first parameter and
+#' @param intfun function which takes intensities as first parameter and
 #'     returns a `logical` of length equal to the number of peaks in the
 #'     spectrum.
 #'
 #' @author Johannes Rainer
 #'
 #' @noRd
-.peaks_filter_intensity_function <- function(x, spectrumMsLevel, intensity,
-                                             msLevel = spectrumMsLevel, ...) {
+.peaks_filter_intensity_function <- function(x, spectrumMsLevel, intfun,
+                                             msLevel = spectrumMsLevel,
+                                             args = list(), ...) {
     if (!spectrumMsLevel %in% msLevel || !length(x))
         return(x)
-    keep <- intensity(x[, "intensity"])
+    keep <- do.call(intfun, args = c(list(x[, "intensity"]), args))
     if (!is.logical(keep) || length(keep) != nrow(x))
         stop("Error in filterIntensity: the provided function does not return ",
              "a logical vector of length equal to the number of peaks.",

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -282,7 +282,8 @@ joinSpectraData(x, y, by.x = "spectrumId", by.y, suffix.y = ".y")
 \S4method{filterIntensity}{Spectra}(
   object,
   intensity = c(0, Inf),
-  msLevel. = unique(msLevel(object))
+  msLevel. = unique(msLevel(object)),
+  ...
 )
 
 \S4method{filterIsolationWindow}{Spectra}(object, mz = numeric())
@@ -956,7 +957,8 @@ intensities that are within the provided range or match the criteria of
 the provided function. For the former, parameter \code{intensity} has to be a
 \code{numeric} defining the intensity range, for the latter a \code{function} that
 takes the intensity values of the spectrum and returns a \code{logical} whether
-the peak should be retained or not (see examples below for details). To
+the peak should be retained or not (see examples below for details) -
+additional parameters to the function can be passed with \code{...}. To
 remove only peaks with intensities below a certain threshold, say 100, use
 \code{intensity = c(100, Inf)}. Note: also a single value can be passed with
 the \code{intensity} parameter in which case an upper limit of \code{Inf} is used.
@@ -1210,13 +1212,19 @@ lengths(mz(data))
 ## In addition it is possible to pass a function to `filterIntensity`: in
 ## the example below we want to keep only peaks that have an intensity which
 ## is larger than one third of the maximal peak intensity in that spectrum.
-keep_peaks <- function(x) {
-    x > max(x, na.rm = TRUE) / 3
+keep_peaks <- function(x, prop = 3) {
+    x > max(x, na.rm = TRUE) / prop
 }
 res2 <- filterIntensity(data, intensity = keep_peaks)
 intensity(res2)[[1L]]
 intensity(data)[[1L]]
 
+## We can also change the proportion by simply passing the `prop` parameter
+## to the function. To keep only peaks that have an intensity which is
+## larger than half of the maximum intensity:
+res2 <- filterIntensity(data, intensity = keep_peaks, prop = 2)
+intensity(res2)[[1L]]
+intensity(data)[[1L]]
 
 ## Since data manipulation operations are by default not directly applied to
 ## the data but only added to the internal lazy evaluation queue, it is also

--- a/tests/testthat/test_MsBackendDataFrame.R
+++ b/tests/testthat/test_MsBackendDataFrame.R
@@ -506,8 +506,6 @@ test_that("spectraData, spectraData<-, MsBackendDataFrame works", {
 test_that("show,MsBackendDataFrame works", {
     be <- MsBackendDataFrame()
     expect_output(show(be), "MsBackendDataFrame")
-    df <- DataFrame(rt = c(1.2, 1.3))
-    be <- backendInitialize(be, df)
 })
 
 test_that("[,MsBackendDataFrame works", {

--- a/tests/testthat/test_MsBackendDataFrame.R
+++ b/tests/testthat/test_MsBackendDataFrame.R
@@ -505,7 +505,7 @@ test_that("spectraData, spectraData<-, MsBackendDataFrame works", {
 
 test_that("show,MsBackendDataFrame works", {
     be <- MsBackendDataFrame()
-    show(be)
+    expect_output(show(be), "MsBackendDataFrame")
     df <- DataFrame(rt = c(1.2, 1.3))
     be <- backendInitialize(be, df)
 })

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1016,6 +1016,16 @@ test_that("filterIntensity,Spectra works", {
                            msLevel = 1L)
     expect_equal(intensity(res)[[1L]], c(3, 4))
     expect_equal(intensity(res)[[2L]], c(1, 2, 3, 4, 5))
+
+    ## Passing additional parameters.
+    filt_fun <- function(x, thresh = 1) x > thresh
+    res <- filterIntensity(sps, intensity = filt_fun)
+    expect_equal(intensity(res)[[1L]], c(2:4))
+    expect_equal(intensity(res)[[2L]], c(2:5))
+
+    res <- filterIntensity(sps, intensity = filt_fun, thresh = 2)
+    expect_equal(intensity(res)[[1L]], c(3:4))
+    expect_equal(intensity(res)[[2L]], c(3:5))
 })
 
 test_that("compareSpectra works", {

--- a/tests/testthat/test_peaks-functions.R
+++ b/tests/testthat/test_peaks-functions.R
@@ -47,12 +47,12 @@ test_that(".peaks_filter_intensity_function works", {
     ints <- c(5, 3, 12, 14.4, 13.3, 9, 3, 0, NA, 21, 89, 55, 33, 5, 2)
     x <- cbind(mz = seq_along(ints), intensity = ints)
     res <- .peaks_filter_intensity_function(
-        x, spectrumMsLevel = 1L, intensity = function(x) x > 0)
+        x, spectrumMsLevel = 1L, intfun = function(x) x > 0)
     expect_equal(res[, 1], c(1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15))
 
     res <- .peaks_filter_intensity_function(
         x, spectrumMsLevel = 1L,
-        intensity = function(z) z > max(z, na.rm = TRUE) / 2)
+        intfun = function(z) z > max(z, na.rm = TRUE) / 2)
     expect_true(all(res[, "intensity"] > 89/2))
 
     res <- .peaks_filter_intensity_function(x, spectrumMsLevel = 1L,


### PR DESCRIPTION
This PR mainly adds support for passing arguments to the filter function of `filterIntensity` (issue #164).