### PR TITLE
fix: per-file filtering in filterPrecursorScan (issue #194)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.3.1
+Version: 1.3.2
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Spectra 1.3
 
+## Changes in 1.3.2
+
+- Add parameter `f` to `filterPrecursorScan` to fix issue
+  [#194](https://github.com/rformassspectrometry/Spectra/issues/194).
+
 ## Changes in 1.3.1
 
 - Add `estimatePrecursorIntensity` function (issue

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -346,7 +346,9 @@ NULL
 #'
 #' - `filterPrecursorScan`: retains parent (e.g. MS1) and children scans (e.g.
 #'   MS2) of acquisition number `acquisitionNum`. Returns the filtered
-#'   `Spectra` (with spectra in their original order).
+#'   `Spectra` (with spectra in their original order). Parameter `f` allows to
+#'   define which spectra belong to the same sample or original data file (
+#'   defaults to `f = dataOrigin(object)`).
 #'
 #' - `filterRt`: retains spectra of MS level `msLevel` with retention
 #'   times (in seconds) within (`>=`) `rt[1]` and (`<=`)
@@ -598,8 +600,9 @@ NULL
 #'     backends changing this parameter can lead to errors.
 #'     For `combineSpectra`: `factor` defining the grouping of the spectra that
 #'     should be combined. For `spectrapply`: `factor` how `object` should be
-#'     splitted. For `estimatePrecursorIntensity`: defining which spectra belong
-#'     to the same original data file (sample). Defaults to `f = dataOrigin(x)`.
+#'     splitted. For `estimatePrecursorIntensity` and `filterPrecursorScan`:
+#'     defining which spectra belong to the same original data file (sample).
+#'     Defaults to `f = dataOrigin(x)`.
 #'
 #' @param FUN For `addProcessing`: function to be applied to the peak matrix
 #'     of each spectrum in `object`. For `compareSpectra`: function to compare
@@ -1860,9 +1863,10 @@ setMethod("filterPrecursorCharge", "Spectra",
 
 #' @rdname Spectra
 setMethod("filterPrecursorScan", "Spectra",
-          function(object, acquisitionNum= integer()) {
+          function(object, acquisitionNum= integer(), f = dataOrigin(object)) {
               object@backend <- filterPrecursorScan(object@backend,
-                                                    acquisitionNum)
+                                                    acquisitionNum,
+                                                    f = dataOrigin(object))
               object@processing <- .logging(
                   object@processing,
                   "Filter: select parent/children scans for ",

--- a/man/MsBackend.Rd
+++ b/man/MsBackend.Rd
@@ -131,7 +131,7 @@
 
 \S4method{filterPrecursorCharge}{MsBackend}(object, z = integer())
 
-\S4method{filterPrecursorScan}{MsBackend}(object, acquisitionNum = integer())
+\S4method{filterPrecursorScan}{MsBackend}(object, acquisitionNum = integer(), f = dataOrigin(object))
 
 \S4method{filterRt}{MsBackend}(object, rt = numeric(), msLevel. = unique(msLevel(object)))
 
@@ -272,6 +272,11 @@ to be used as filter.}
 acquisition number of the spectra to which the object should be
 subsetted.}
 
+\item{f}{\code{factor} defining the grouping to split \code{x}. See \code{\link[=split]{split()}}. For
+\code{filterPrecursorScan}: factor defining from which original data files
+the spectra derive to avoid selecting spectra from different
+samples/files. Defaults to \code{f = dataOrigin(object)}.}
+
 \item{rt}{for \code{filterRt}: \code{numeric(2)} defining the retention time range to
 be used to subset/filter \code{object}.}
 
@@ -287,8 +292,6 @@ names of the spectra variables to which the backend should be subsetted.}
 \item{columns}{For \code{spectraData} accessor: optional \code{character} with column
 names (spectra variables) that should be included in the
 returned \code{DataFrame}. By default, all columns are returned.}
-
-\item{f}{\code{factor} defining the grouping to split \code{x}. See \code{\link[=split]{split()}}.}
 
 \item{drop}{For \code{[}: not considered.}
 
@@ -459,7 +462,9 @@ charge(s).
 Implementation of this method is optional since a default implementation
 for \code{MsBackend} is available.
 \item \code{filterPrecursorScan}: retains parent (e.g. MS1) and children scans (e.g.
-MS2) of acquisition number \code{acquisitionNum}.
+MS2) of acquisition number \code{acquisitionNum}. Parameter \code{f} is supposed to
+define the origin of the spectra (i.e. the original data file) to ensure
+related spectra from the same file/sample are selected and retained.
 Implementation of this method is optional since a default implementation
 for \code{MsBackend} is available.
 \item \code{filterRt}: retains spectra of MS level \code{msLevel} with retention times

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -322,7 +322,7 @@ estimatePrecursorIntensity(
 
 \S4method{filterPrecursorCharge}{Spectra}(object, z = integer())
 
-\S4method{filterPrecursorScan}{Spectra}(object, acquisitionNum = integer())
+\S4method{filterPrecursorScan}{Spectra}(object, acquisitionNum = integer(), f = dataOrigin(object))
 
 \S4method{filterRt}{Spectra}(object, rt = numeric(), msLevel. = unique(msLevel(object)))
 
@@ -392,8 +392,9 @@ parallelized copying of the spectra data to the new backend. For some
 backends changing this parameter can lead to errors.
 For \code{combineSpectra}: \code{factor} defining the grouping of the spectra that
 should be combined. For \code{spectrapply}: \code{factor} how \code{object} should be
-splitted. For \code{estimatePrecursorIntensity}: defining which spectra belong
-to the same original data file (sample). Defaults to \code{f = dataOrigin(x)}.}
+splitted. For \code{estimatePrecursorIntensity} and \code{filterPrecursorScan}:
+defining which spectra belong to the same original data file (sample).
+Defaults to \code{f = dataOrigin(x)}.}
 
 \item{BPPARAM}{Parallel setup configuration. See \code{\link[=bpparam]{bpparam()}} for more
 information. This is passed directly to the \code{\link[=backendInitialize]{backendInitialize()}} method
@@ -877,7 +878,9 @@ a precursor m/z for a target m/z accepting a small difference in \emph{ppm}.
 charge(s).
 \item \code{filterPrecursorScan}: retains parent (e.g. MS1) and children scans (e.g.
 MS2) of acquisition number \code{acquisitionNum}. Returns the filtered
-\code{Spectra} (with spectra in their original order).
+\code{Spectra} (with spectra in their original order). Parameter \code{f} allows to
+define which spectra belong to the same sample or original data file (
+defaults to \code{f = dataOrigin(object)}).
 \item \code{filterRt}: retains spectra of MS level \code{msLevel} with retention
 times (in seconds) within (\code{>=}) \code{rt[1]} and (\code{<=})
 \code{rt[2]}. Returns the filtered \code{Spectra} (with spectra in their

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -962,6 +962,10 @@ test_that("filterPrecursorScan,Spectra works", {
     res <- filterPrecursorScan(sps, c(1087L, 1214L))
     expect_true(sum(msLevel(res) == 1) == 2)
     expect_true(all(c(1087L, 1214L) %in% acquisitionNum(res)))
+
+    sps <- c(sps, Spectra(sciex_mzr))
+    res <- filterPrecursorScan(sps, 1057)
+    expect_equal(acquisitionNum(res), c(1054L, 1057L))
 })
 
 test_that("filterRt,Spectra works", {


### PR DESCRIPTION
- Add parameter `f = dataOrigin(object)` to `filterPrecursorScan` to allow
  filtering within each sample/file. This fixes issue #194.