### PR TITLE
feat: filterMzValues supports removing peaks (issue #209)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.3.4
+Version: 1.3.5
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Spectra 1.3
 
+## Changes in 1.3.5
+
+- `filterMzValues` supports also removing peaks matching specified m/z values
+  (issue [#209](https://github.com/rformassspectrometry/Spectra/issues/209)).
+
 ## Changes in 1.3.4
 
 - Add list of additional R packages and repositories providing `MsBackend`

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -328,10 +328,11 @@ NULL
 #'   that are within the provided m/z range.
 #'
 #' - `filterMzValues`: filters the object keeping only peaks in each spectrum
-#'   that match the provided m/z value(s) considering also the absolute
-#'   `tolerance` and m/z-relative `ppm` (`tolerance` and `ppm` can be either
-#'   of length 1 or equal to the length of `mz` to define a different tolerance
-#'   for each m/z).
+#'   that match the provided m/z value(s) (if parameter `remove = FALSE`, the
+#'   default) or removing them (if parameter `remove = TRUE`). The m/z matching
+#'   considers also the absolute `tolerance` and m/z-relative `ppm` values.
+#'   `tolerance` and `ppm` can be either of length 1 or equal to the length of
+#'   `mz` to define a different matching tolerance for each provided m/z.
 #'
 #' - `filterPolarity`: filters the object keeping only spectra matching the
 #'   provided polarity. Returns the filtered `Spectra` (with spectra in their
@@ -698,6 +699,10 @@ NULL
 #' @param processingQueue For `Spectra`: optional `list` of
 #'     [ProcessingStep-class] objects.
 #'
+#' @param remove For `filterMzValues`: `logical(1)` whether the matching peaks
+#'     should be retained (`remove = FALSE`, the default`) or dropped
+#'     (`remove = TRUE`).
+#'
 #' @param SIMPLIFY For `compareSpectra` whether the result matrix should be
 #'     *simplified* to a `numeric` if possible (i.e. if either `x` or `y` is
 #'     of length 1).
@@ -907,6 +912,12 @@ NULL
 #'
 #' ## Filter a Spectra keeping only peaks matching certain m/z values
 #' sps_sub <- filterMzValues(data, mz = c(103, 104), tolerance = 0.3)
+#' mz(sps_sub)
+#'
+#' ## This function can also be used to remove specific peaks from a spectrum
+#' ## by setting `remove = TRUE`.
+#' sps_sub <- filterMzValues(data, mz = c(103, 104),
+#'     tolerance = 0.3, remove = TRUE)
 #' mz(sps_sub)
 #'
 #' ## Filter a Spectra keeping only peaks within a m/z range
@@ -1800,7 +1811,7 @@ setMethod("filterMzRange", "Spectra",
 #' @export
 setMethod("filterMzValues", "Spectra",
           function(object, mz = numeric(), tolerance = 0, ppm = 20,
-                   msLevel. = unique(msLevel(object))) {
+                   msLevel. = unique(msLevel(object)), remove = FALSE) {
               if (!.check_ms_level(object, msLevel.))
                   return(object)
               l <- length(mz)
@@ -1819,6 +1830,7 @@ setMethod("filterMzValues", "Spectra",
               object <- addProcessing(object, .peaks_filter_mz_value,
                                       mz = mz, tolerance = tolerance,
                                       ppm = ppm, msLevel = msLevel.,
+                                      remove = remove,
                                       spectraVariables = "msLevel")
               if (length(mz) <= 3)
                   what <- paste0(format(mz, digits = 4), collapse = ", ")

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -638,6 +638,10 @@ NULL
 #' @param k For `pickPeaks`: `integer(1)`, number of values left and right of
 #'  the peak that should be considered in the weighted mean calculation.
 #'
+#' @param keep For `filterMzValues`: `logical(1)` whether the matching peaks
+#'     should be retained (`keep = TRUE`, the default`) or dropped
+#'     (`keep = FALSE`).
+#'
 #' @param MAPFUN For `compareSpectra`: function to map/match peaks between the
 #'     two compared spectra. See [joinPeaks()] for more information and possible
 #'     functions.
@@ -698,10 +702,6 @@ NULL
 #'
 #' @param processingQueue For `Spectra`: optional `list` of
 #'     [ProcessingStep-class] objects.
-#'
-#' @param remove For `filterMzValues`: `logical(1)` whether the matching peaks
-#'     should be retained (`remove = FALSE`, the default`) or dropped
-#'     (`remove = TRUE`).
 #'
 #' @param SIMPLIFY For `compareSpectra` whether the result matrix should be
 #'     *simplified* to a `numeric` if possible (i.e. if either `x` or `y` is
@@ -915,9 +915,9 @@ NULL
 #' mz(sps_sub)
 #'
 #' ## This function can also be used to remove specific peaks from a spectrum
-#' ## by setting `remove = TRUE`.
+#' ## by setting `keep = FALSE`.
 #' sps_sub <- filterMzValues(data, mz = c(103, 104),
-#'     tolerance = 0.3, remove = TRUE)
+#'     tolerance = 0.3, keep = FALSE)
 #' mz(sps_sub)
 #'
 #' ## Filter a Spectra keeping only peaks within a m/z range
@@ -1811,7 +1811,7 @@ setMethod("filterMzRange", "Spectra",
 #' @export
 setMethod("filterMzValues", "Spectra",
           function(object, mz = numeric(), tolerance = 0, ppm = 20,
-                   msLevel. = unique(msLevel(object)), remove = FALSE) {
+                   msLevel. = unique(msLevel(object)), keep = TRUE) {
               if (!.check_ms_level(object, msLevel.))
                   return(object)
               l <- length(mz)
@@ -1830,14 +1830,16 @@ setMethod("filterMzValues", "Spectra",
               object <- addProcessing(object, .peaks_filter_mz_value,
                                       mz = mz, tolerance = tolerance,
                                       ppm = ppm, msLevel = msLevel.,
-                                      remove = remove,
-                                      spectraVariables = "msLevel")
+                                      keep = keep, spectraVariables = "msLevel")
               if (length(mz) <= 3)
                   what <- paste0(format(mz, digits = 4), collapse = ", ")
               else what <- ""
+              if (keep)
+                  keep_or_remove <- "select"
+              else keep_or_remove <- "remove"
               object@processing <- .logging(
-                  object@processing, "Filter: select peaks matching provided ",
-                  "m/z values ", what)
+                  object@processing, "Filter: ", keep_or_remove,
+                  " peaks matching provided m/z values ", what)
               object
           })
 

--- a/R/peaks-functions.R
+++ b/R/peaks-functions.R
@@ -130,6 +130,9 @@ NULL
 #'
 #' @param ppm `numeric` with the ppm. Can be of length 1 or equal length `mz`.
 #'
+#' @param remove `logical(1)` whether the matching peaks should be retained
+#'     (`remove = FALSE`, the default`) or dropped (`remove = TRUE`).
+#'
 #' @author Johannes Rainer
 #'
 #' @importFrom MsCoreUtils closest
@@ -137,12 +140,19 @@ NULL
 #' @noRd
 .peaks_filter_mz_value <- function(x, spectrumMsLevel, mz = numeric(),
                                    tolerance = 0, ppm = 20,
-                                   msLevel = spectrumMsLevel, ...) {
+                                   msLevel = spectrumMsLevel,
+                                   remove = FALSE, ...) {
     if (!spectrumMsLevel %in% msLevel || !length(x))
         return(x)
     idx <- closest(mz, x[, "mz"], tolerance = tolerance, ppm = ppm,
                    duplicates = "closest", .check = FALSE)
-    x[idx[!is.na(idx)], , drop = FALSE]
+    idx <- idx[!is.na(idx)]
+    if (remove) {
+        if (length(idx))
+            x[-idx, , drop = FALSE]
+        else x
+    } else
+        x[idx, , drop = FALSE]
 }
 
 #' @description

--- a/R/peaks-functions.R
+++ b/R/peaks-functions.R
@@ -130,8 +130,8 @@ NULL
 #'
 #' @param ppm `numeric` with the ppm. Can be of length 1 or equal length `mz`.
 #'
-#' @param remove `logical(1)` whether the matching peaks should be retained
-#'     (`remove = FALSE`, the default`) or dropped (`remove = TRUE`).
+#' @param keep `logical(1)` whether the matching peaks should be retained
+#'     (`keep = TRUE`, the default`) or dropped (`keep = FALSE`).
 #'
 #' @author Johannes Rainer
 #'
@@ -141,18 +141,19 @@ NULL
 .peaks_filter_mz_value <- function(x, spectrumMsLevel, mz = numeric(),
                                    tolerance = 0, ppm = 20,
                                    msLevel = spectrumMsLevel,
-                                   remove = FALSE, ...) {
+                                   keep = TRUE, ...) {
     if (!spectrumMsLevel %in% msLevel || !length(x))
         return(x)
     idx <- closest(mz, x[, "mz"], tolerance = tolerance, ppm = ppm,
                    duplicates = "closest", .check = FALSE)
     idx <- idx[!is.na(idx)]
-    if (remove) {
+    if (keep)
+        x[idx, , drop = FALSE]
+    else {
         if (length(idx))
             x[-idx, , drop = FALSE]
         else x
-    } else
-        x[idx, , drop = FALSE]
+    }
 }
 
 #' @description

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -314,7 +314,7 @@ estimatePrecursorIntensity(
   tolerance = 0,
   ppm = 20,
   msLevel. = unique(msLevel(object)),
-  remove = FALSE
+  keep = TRUE
 )
 
 \S4method{filterPolarity}{Spectra}(object, polarity = integer())
@@ -535,8 +535,8 @@ returns a \code{logical} (same length then peaks in the spectrum) whether the
 peak should be retained or not. Defaults to \code{intensity = c(0, Inf)} thus
 only peaks with \code{NA} intensity are removed.}
 
-\item{remove}{For \code{filterMzValues}: \code{logical(1)} whether the matching peaks
-should be retained (\code{remove = FALSE}, the default\verb{) or dropped (}remove = TRUE`).}
+\item{keep}{For \code{filterMzValues}: \code{logical(1)} whether the matching peaks
+should be retained (\code{keep = TRUE}, the default\verb{) or dropped (}keep = FALSE`).}
 
 \item{polarity}{for \code{filterPolarity}: \code{integer} specifying the polarity to
 to subset \code{object}.}
@@ -1226,9 +1226,9 @@ sps_sub <- filterMzValues(data, mz = c(103, 104), tolerance = 0.3)
 mz(sps_sub)
 
 ## This function can also be used to remove specific peaks from a spectrum
-## by setting `remove = TRUE`.
+## by setting `keep = FALSE`.
 sps_sub <- filterMzValues(data, mz = c(103, 104),
-    tolerance = 0.3, remove = TRUE)
+    tolerance = 0.3, keep = FALSE)
 mz(sps_sub)
 
 ## Filter a Spectra keeping only peaks within a m/z range

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -313,7 +313,8 @@ estimatePrecursorIntensity(
   mz = numeric(),
   tolerance = 0,
   ppm = 20,
-  msLevel. = unique(msLevel(object))
+  msLevel. = unique(msLevel(object)),
+  remove = FALSE
 )
 
 \S4method{filterPolarity}{Spectra}(object, polarity = integer())
@@ -533,6 +534,9 @@ filtering, or a \code{function} that takes the intensities as input and
 returns a \code{logical} (same length then peaks in the spectrum) whether the
 peak should be retained or not. Defaults to \code{intensity = c(0, Inf)} thus
 only peaks with \code{NA} intensity are removed.}
+
+\item{remove}{For \code{filterMzValues}: \code{logical(1)} whether the matching peaks
+should be retained (\code{remove = FALSE}, the default\verb{) or dropped (}remove = TRUE`).}
 
 \item{polarity}{for \code{filterPolarity}: \code{integer} specifying the polarity to
 to subset \code{object}.}
@@ -864,10 +868,11 @@ the MS level specified with argument \code{msLevel}. Returns the filtered
 \item \code{filterMzRange}: filters the object keeping only peaks in each spectrum
 that are within the provided m/z range.
 \item \code{filterMzValues}: filters the object keeping only peaks in each spectrum
-that match the provided m/z value(s) considering also the absolute
-\code{tolerance} and m/z-relative \code{ppm} (\code{tolerance} and \code{ppm} can be either
-of length 1 or equal to the length of \code{mz} to define a different tolerance
-for each m/z).
+that match the provided m/z value(s) (if parameter \code{remove = FALSE}, the
+default) or removing them (if parameter \code{remove = TRUE}). The m/z matching
+considers also the absolute \code{tolerance} and m/z-relative \code{ppm} values.
+\code{tolerance} and \code{ppm} can be either of length 1 or equal to the length of
+\code{mz} to define a different matching tolerance for each provided m/z.
 \item \code{filterPolarity}: filters the object keeping only spectra matching the
 provided polarity. Returns the filtered \code{Spectra} (with spectra in their
 original order).
@@ -1218,6 +1223,12 @@ filterPrecursorMz(data_filt, mz = 543.23 + ppm(c(-543.23, 543.23), 10))
 
 ## Filter a Spectra keeping only peaks matching certain m/z values
 sps_sub <- filterMzValues(data, mz = c(103, 104), tolerance = 0.3)
+mz(sps_sub)
+
+## This function can also be used to remove specific peaks from a spectrum
+## by setting `remove = TRUE`.
+sps_sub <- filterMzValues(data, mz = c(103, 104),
+    tolerance = 0.3, remove = TRUE)
 mz(sps_sub)
 
 ## Filter a Spectra keeping only peaks within a m/z range

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1424,6 +1424,16 @@ test_that("filterMzValue,Spectra works", {
                  "length 1 or equal")
     expect_error(filterMzValues(sps, mz = c(56, 12), ppm = c(1, 2, 3)),
                  "length 1 or equal")
+
+    ## remove
+    res <- filterMzValues(sps, mz = 56, remove = TRUE)
+    expect_equal(mz(res)[[1L]], mz(sps)[[1L]][-4])
+    res <- filterMzValues(sps, mz = 56, remove = TRUE, tolerance = 0.1)
+    expect_equal(mz(res)[[1L]], mz(sps)[[1L]][-4])
+    expect_equal(mz(res)[[2L]], mz(sps)[[2L]][-3])
+
+    res <- filterMzValues(sps, mz = c(1243, 244), remove = TRUE)
+    expect_equal(mz(res), mz(sps))
 })
 
 test_that("dropNaSpectraVariables works with MsBackendMzR", {

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1426,13 +1426,13 @@ test_that("filterMzValue,Spectra works", {
                  "length 1 or equal")
 
     ## remove
-    res <- filterMzValues(sps, mz = 56, remove = TRUE)
+    res <- filterMzValues(sps, mz = 56, keep = FALSE)
     expect_equal(mz(res)[[1L]], mz(sps)[[1L]][-4])
-    res <- filterMzValues(sps, mz = 56, remove = TRUE, tolerance = 0.1)
+    res <- filterMzValues(sps, mz = 56, keep = FALSE, tolerance = 0.1)
     expect_equal(mz(res)[[1L]], mz(sps)[[1L]][-4])
     expect_equal(mz(res)[[2L]], mz(sps)[[2L]][-3])
 
-    res <- filterMzValues(sps, mz = c(1243, 244), remove = TRUE)
+    res <- filterMzValues(sps, mz = c(1243, 244), keep = FALSE)
     expect_equal(mz(res), mz(sps))
 })
 

--- a/tests/testthat/test_peaks-functions.R
+++ b/tests/testthat/test_peaks-functions.R
@@ -211,14 +211,14 @@ test_that(".peaks_match_mz_value works", {
 
     ## remove
     res <- .peaks_filter_mz_value(p, 1L, mz = 5, tolerance = 1,
-                                  remove = TRUE)
+                                  keep = FALSE)
     expect_equal(res, p[-2, ])
     res <- .peaks_filter_mz_value(p, 1L, mz = c(5, 6, 20),
-                                  tolerance = 0, remove = TRUE)
+                                  tolerance = 0, keep = FALSE)
     expect_equal(res, p)
     res <- .peaks_filter_mz_value(p, 1L, mz = c(123, 742.2),
                                   tolerance = c(0.2, 1),
-                                  remove = TRUE)
+                                  keep = FALSE)
     expect_equal(res, p[-c(3, 8), ])
 })
 

--- a/tests/testthat/test_peaks-functions.R
+++ b/tests/testthat/test_peaks-functions.R
@@ -208,6 +208,18 @@ test_that(".peaks_match_mz_value works", {
     res <- .peaks_filter_mz_value(p, 1L, mz = c(123, 742.2),
                                   tolerance = c(0.2, 1))
     expect_equal(unname(res[, "intensity"]), c(3, 8))
+
+    ## remove
+    res <- .peaks_filter_mz_value(p, 1L, mz = 5, tolerance = 1,
+                                  remove = TRUE)
+    expect_equal(res, p[-2, ])
+    res <- .peaks_filter_mz_value(p, 1L, mz = c(5, 6, 20),
+                                  tolerance = 0, remove = TRUE)
+    expect_equal(res, p)
+    res <- .peaks_filter_mz_value(p, 1L, mz = c(123, 742.2),
+                                  tolerance = c(0.2, 1),
+                                  remove = TRUE)
+    expect_equal(res, p[-c(3, 8), ])
 })
 
 test_that("joinPeaksGnps works", {

--- a/vignettes/Spectra.Rmd
+++ b/vignettes/Spectra.Rmd
@@ -295,8 +295,8 @@ the `?Spectra` help):
 - `filterEmptySpectra`: remove spectra without mass peaks.
 - `filterMzRange`: subset spectra keeping only peaks with an m/z within the
   provided m/z range.
-- `filterMzValues`: subset spectra keeping only peaks matching provided m/z
-  value(s).
+- `filterMzValues`: subset spectra keeping or removing peaks matching provided
+  m/z value(s).
 - `filterIsolationWindow`: keep spectra with the provided `mz` in their
   isolation window (m/z range).
 - `filterMsLevel`: filter by MS level.


### PR DESCRIPTION
- Add parameter `remove` to `filterMzValues` to allow removing instead of
  keeping matching peaks.