### PR TITLE
fix: fix random errors with MsBackendMzR on macOS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.3.6
+Version: 1.3.7
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Spectra 1.3
 
+## Changes in 1.3.7
+
+- Add fix from `MSnbase` (issue
+  [#170](https://github.com/lgatto/MSnbase/issues/170)) to `Spectra`: on macOS
+  require reading also the spectrum header before reading the peaks data.
+
 ## Changes in 1.3.6
 
 - Documentation updates for `combineSpectra` and `combinePeaks`.

--- a/R/MsBackendMzR-functions.R
+++ b/R/MsBackendMzR-functions.R
@@ -58,12 +58,15 @@ MsBackendMzR <- function() {
 #' @return list of `matrix`
 #'
 #' @noRd
-.mzR_peaks <- function(x = character(), scanIndex = integer()) {
+.mzR_peaks <- function(x = character(), scanIndex = integer(),
+                       readHeader = FALSE) {
     if (length(x) != 1)
         stop("'x' should have length 1")
     msd <- mzR::openMSfile(x)
     on.exit(mzR::close(msd))
-    ## hd_spectra <- mzR::header(msd, max(scanIndex))
+    ## That below is required on macOS - otherwise we get random errors
+    if (readHeader && length(scanIndex))
+        hd_spectra <- mzR::header(msd, max(scanIndex))
     pks <- mzR::peaks(msd, scanIndex)
     if (is.matrix(pks))
         pks <- list(pks)

--- a/R/MsBackendMzR.R
+++ b/R/MsBackendMzR.R
@@ -83,12 +83,14 @@ setMethod("peaksData", "MsBackendMzR", function(object) {
     if (!length(object))
         return(list())
     fls <- unique(object@spectraData$dataStorage)
+    read_header <- getOption("READ_HEADER", FALSE)
     if (length(fls) > 1) {
         f <- factor(dataStorage(object), levels = fls)
         unsplit(mapply(FUN = .mzR_peaks, fls, split(scanIndex(object), f),
+                       MoreArgs = list(readHeader = read_header),
                        SIMPLIFY = FALSE, USE.NAMES = FALSE), f)
     } else
-        .mzR_peaks(fls, scanIndex(object))
+        .mzR_peaks(fls, scanIndex(object), readHeader = read_header)
 })
 
 #' @rdname hidden_aliases

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,4 @@
 .onLoad <- function(libname, pkgname) {
     options(HDF5_COMPRESSION_LEVEL = 3L)
+    options(READ_HEADER = Sys.info()["sysname"] == "Darwin")
 }

--- a/tests/testthat/test_MsBackendMzR-functions.R
+++ b/tests/testthat/test_MsBackendMzR-functions.R
@@ -36,6 +36,9 @@ test_that(".mzR_peaks work", {
     expect_equal(res_13[[1]], res_all[[13]])
 
     expect_error(.mzR_peaks(fls, 13), "length 1")
+
+    expect_equal(.mzR_peaks(fls[1L], hdr$scanIndex),
+                 .mzR_peaks(fls[1L], hdr$scanIndex, readHeader = TRUE))
 })
 
 test_that(".pattern_to_cv works", {


### PR DESCRIPTION
- This adds a fix from MSnbase to address random errors retrieving peak data
  from mzML files using the `MsBackendMzR` backend on macOS (issue #212 )
