### PR TITLE
features: joinSpectraData() checks for key duplicates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## Changes in 1.3.9
 
-- Nothing yet.
+- New features: `joinSpectraData()` now check for duplicated keys in
+  `x` (throws an error) and `y` (thows a warning).
 
 ## Changes in 1.3.8
 

--- a/R/Spectra-functions.R
+++ b/R/Spectra-functions.R
@@ -592,7 +592,7 @@ joinSpectraData <- function(x, y,
 #' @export
 #'
 #' @rdname Spectra
-gprocessingLog <- function(x) {
+processingLog <- function(x) {
     x@processing
 }
 

--- a/R/Spectra-functions.R
+++ b/R/Spectra-functions.R
@@ -533,6 +533,7 @@ joinSpectraData <- function(x, y,
                             by.x = "spectrumId",
                             by.y,
                             suffix.y = ".y") {
+
     stopifnot(inherits(x, "Spectra"))
     stopifnot(inherits(y, "DataFrame"))
     if (missing(by.y))
@@ -557,6 +558,11 @@ joinSpectraData <- function(x, y,
     y <- y[y[[by.y]] %in% spectraData(x)[[by.x]], ]
     k <- match(y[[by.y]], spectraData(x)[[by.x]])
     n <- length(x)
+    ## check for by.x and by.y keys duplicates
+    if (anyDuplicated(spectraData(x)[[by.x]]))
+        stop("Duplicates found in the 'x' key!")
+    if (anyDuplicated(y[[by.y]]))
+        warning("Duplicates found in the 'y' key. Only last instance will be kept!")
     ## Don't need by.y anymore
     y_vars <- y_vars[-grep(by.y, y_vars)]
     y <- y[, y_vars]
@@ -586,7 +592,7 @@ joinSpectraData <- function(x, y,
 #' @export
 #'
 #' @rdname Spectra
-processingLog <- function(x) {
+gprocessingLog <- function(x) {
     x@processing
 }
 

--- a/R/Spectra-functions.R
+++ b/R/Spectra-functions.R
@@ -565,7 +565,7 @@ joinSpectraData <- function(x, y,
         warning("Duplicates found in the 'y' key. Only last instance will be kept!")
     ## Don't need by.y anymore
     y_vars <- y_vars[-grep(by.y, y_vars)]
-    y <- y[, y_vars]
+    y <- y[, y_vars, drop = FALSE]
     ## Check if there are any shared x_vars and y_vars. If so, the
     ## y_vars are appended suffix.y.
     if (length(xy_vars <- intersect(x_vars, y_vars))) {

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -386,8 +386,9 @@ NULL
 #'    - Duplicated Spectra keys (i.e. `x[[by.x]]`) are not
 #'      allowed. Duplicated keys in the `DataFrame` (i.e `y[[by.y]]`)
 #'      throw a warning and only the last occurrence is kept. These
-#'      should be explored and ideally be removed using for example
-#'      the `QFeatures::reduceDataFrame()` function.
+#'      should be explored and ideally be removed using for
+#'      `QFeatures::reduceDataFrame()`, `PMS::reducePSMs()` or similar
+#'      functions.
 #'
 #' Several `Spectra` objects can be concatenated into a single object with the
 #' `c` or the `concatenateSpectra` function. Concatenation will fail if the

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -942,7 +942,7 @@ NULL
 #'
 #' ## Adding new spectra variables
 #' sciex1 <- filterDataOrigin(sciex, dataOrigin(sciex)[1])
-#' spv <- DataFrame(spectrumId = sciex2=1$spectrumId[3:12], ## used for merging
+#' spv <- DataFrame(spectrumId = sciex1$spectrumId[3:12], ## used for merging
 #'                  var1 = rnorm(10),
 #'                  var2 = sample(letters, 10))
 #' spv

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -383,6 +383,12 @@ NULL
 #'       `suffix.y`. This is to avoid modifying any core spectra
 #'       variables that would lead to an invalid object.
 #'
+#'    - Duplicated Spectra keys (i.e. `x[[by.x]]`) are not
+#'      allowed. Duplicated keys in the `DataFrame` (i.e `y[[by.y]]`)
+#'      throw a warning and only the last occurrence is kept. These
+#'      should be explored and ideally be removed using for example
+#'      the `QFeatures::reduceDataFrame()` function.
+#'
 #' Several `Spectra` objects can be concatenated into a single object with the
 #' `c` or the `concatenateSpectra` function. Concatenation will fail if the
 #' processing queue of any of the `Spectra` objects is not empty or if

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -941,12 +941,13 @@ NULL
 #'
 #'
 #' ## Adding new spectra variables
-#' spv <- DataFrame(spectrumId = sciex$spectrumId[3:12], ## used for merging
+#' sciex1 <- filterDataOrigin(sciex, dataOrigin(sciex)[1])
+#' spv <- DataFrame(spectrumId = sciex2=1$spectrumId[3:12], ## used for merging
 #'                  var1 = rnorm(10),
 #'                  var2 = sample(letters, 10))
 #' spv
 #'
-#' sciex2 <- joinSpectraData(sciex, spv, by.y = "spectrumId")
+#' sciex2 <- joinSpectraData(sciex1, spv, by.y = "spectrumId")
 #'
 #' spectraVariables(sciex2)
 #' spectraData(sciex2)[1:13, c("spectrumId", "var1", "var2")]

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -917,8 +917,9 @@ variables that would lead to an invalid object.
 \item Duplicated Spectra keys (i.e. \code{x[[by.x]]}) are not
 allowed. Duplicated keys in the \code{DataFrame} (i.e \code{y[[by.y]]})
 throw a warning and only the last occurrence is kept. These
-should be explored and ideally be removed using for example
-the \code{QFeatures::reduceDataFrame()} function.
+should be explored and ideally be removed using for
+\code{QFeatures::reduceDataFrame()}, \code{PMS::reducePSMs()} or similar
+functions.
 }
 }
 

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -1251,12 +1251,13 @@ spectraVariables(sciex_noNA)
 
 
 ## Adding new spectra variables
-spv <- DataFrame(spectrumId = sciex$spectrumId[3:12], ## used for merging
+sciex1 <- filterDataOrigin(sciex, dataOrigin(sciex)[1])
+spv <- DataFrame(spectrumId = sciex2=1$spectrumId[3:12], ## used for merging
                  var1 = rnorm(10),
                  var2 = sample(letters, 10))
 spv
 
-sciex2 <- joinSpectraData(sciex, spv, by.y = "spectrumId")
+sciex2 <- joinSpectraData(sciex1, spv, by.y = "spectrumId")
 
 spectraVariables(sciex2)
 spectraData(sciex2)[1:13, c("spectrumId", "var1", "var2")]

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -914,6 +914,11 @@ variables of \code{x} are not modified. It's only the \code{y}
 variables that are appended the suffix defined in
 \code{suffix.y}. This is to avoid modifying any core spectra
 variables that would lead to an invalid object.
+\item Duplicated Spectra keys (i.e. \code{x[[by.x]]}) are not
+allowed. Duplicated keys in the \code{DataFrame} (i.e \code{y[[by.y]]})
+throw a warning and only the last occurrence is kept. These
+should be explored and ideally be removed using for example
+the \code{QFeatures::reduceDataFrame()} function.
 }
 }
 

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -1252,7 +1252,7 @@ spectraVariables(sciex_noNA)
 
 ## Adding new spectra variables
 sciex1 <- filterDataOrigin(sciex, dataOrigin(sciex)[1])
-spv <- DataFrame(spectrumId = sciex2=1$spectrumId[3:12], ## used for merging
+spv <- DataFrame(spectrumId = sciex1$spectrumId[3:12], ## used for merging
                  var1 = rnorm(10),
                  var2 = sample(letters, 10))
 spv

--- a/tests/testthat/test_Spectra-functions.R
+++ b/tests/testthat/test_Spectra-functions.R
@@ -465,7 +465,7 @@ test_that("joinSpectraData key checks work", {
     ## Duplicates in `y` key throw a warning
     sp$key <- paste0("sp", 1:3)
     expect_warning(res <- joinSpectraData(sp, df, by.x = "key"))
-    expect_identical(res$var1, c(20, NA, 30))n
+    expect_identical(res$var1, c(20, NA, 30))
 
     ## No duplicates in any key
     df$key <- paste0("sp", 1:3)

--- a/tests/testthat/test_Spectra-functions.R
+++ b/tests/testthat/test_Spectra-functions.R
@@ -445,6 +445,35 @@ test_that("joinSpectraData works", {
     expect_true(is(ms2$CharList, "CharacterList"))
 })
 
+test_that("joinSpectraData key checks work", {
+    spd <- DataFrame(msLevel = rep(2L, 3),
+                     rtime = c(1.1, 1.2, 1.3),
+                     key = paste0("sp", c(1, 1, 3)))
+    spd$mz <- list(c(100, 103.2, 104.3, 106.5),
+                   c(45.6, 120.4, 190.2),
+                   c(45.6, 120.4, 190.2))
+    spd$intensity <- list(c(200, 400, 34.2, 17),
+                          c(12.3, 15.2, 6.8),
+                          c(12.3, 15.2, 6.8))
+    sp <- Spectra(spd)
+    df <- DataFrame(key = paste0("sp", c(1, 1, 3)),
+                    var1 = c(10, 20, 30))
+
+    ## Duplicates in `x` key aren't allowed
+    expect_error(joinSpectraData(sp, df, by.x = "key"))
+
+    ## Duplicates in `y` key throw a warning
+    sp$key <- paste0("sp", 1:3)
+    expect_warning(res <- joinSpectraData(sp, df, by.x = "key"))
+    expect_identical(res$var1, c(20, NA, 30))n
+
+    ## No duplicates in any key
+    df$key <- paste0("sp", 1:3)
+    res <- joinSpectraData(sp, df, by.x = "key")
+    expect_identical(res$var1, c(10, 20, 30))
+})
+
+
 test_that("processingLog works", {
     sps <- Spectra()
     expect_equal(processingLog(sps), character())


### PR DESCRIPTION
The `joinSpectraData(x, y, by.x, by.y)` function now checks for duplicates in the x and y keys. 

- If there's duplicates in the `Spectra` key (i.e. in `x[[by.x]]`), then an error is thrown. Indeed, this key should be unique and the user would need to sort this out it it wasn't. 
- If there's duplicates in the `y` key (i.e. in `y[[by.y]]`), then a warning is thrown, and the last occurrences of the duplicated entries are used (as as result of using `match()`). The documentation provides guidance how to manage this. 