### PR TITLE
docs: expand examples and description on bin

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -191,7 +191,7 @@ jobs:
           BiocManager::install("SummarizedExperiment", ask = FALSE, update = FALSE)
           BiocManager::install("msdata")
 
-          BiocManager::install("RforMassSpectrometry/MsCoreUtils", ask = FALSE)
+          BiocManager::install("RforMassSpectrometry/MsCoreUtils", ask = FALSE, force = TRUE)
           # BiocManager::install(c("devtools", "usethis", "vdiffr"), dependencies = TRUE, ask = FALSE, update = FALSE)
           ## For running the checks
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -180,7 +180,7 @@ jobs:
           ## Pass #1 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 1 at installing dependencies: local dependencies ****'))
           remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
-
+          BiocManager::install("RforMassSpectrometry/MsCoreUtils", ask = FALSE, force = TRUE)
           ## Pass #2 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 2 at installing dependencies: any remaining dependencies ****'))
           remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
@@ -191,7 +191,6 @@ jobs:
           BiocManager::install("SummarizedExperiment", ask = FALSE, update = FALSE)
           BiocManager::install("msdata")
 
-          BiocManager::install("RforMassSpectrometry/MsCoreUtils", ask = FALSE, force = TRUE)
           # BiocManager::install(c("devtools", "usethis", "vdiffr"), dependencies = TRUE, ask = FALSE, update = FALSE)
           ## For running the checks
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -190,6 +190,8 @@ jobs:
           BiocManager::install("sneumann/mzR", dependencies = TRUE, ask = FALSE, update=FALSE)
           BiocManager::install("SummarizedExperiment", ask = FALSE, update = FALSE)
           BiocManager::install("msdata")
+
+          BiocManager::install("RforMassSpectrometry/MsCoreUtils", ask = FALSE)
           # BiocManager::install(c("devtools", "usethis", "vdiffr"), dependencies = TRUE, ask = FALSE, update = FALSE)
           ## For running the checks
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.5.18
+Version: 1.5.19
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different
@@ -34,7 +34,7 @@ Depends:
 Imports:
     methods,
     IRanges,
-    MsCoreUtils (>= 1.3.3),
+    MsCoreUtils (>= 1.7.5),
     graphics,
     grDevices,
     stats,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Spectra 1.5
 
+## Changes in 1.5.19
+
 ## Changes in 1.5.18
 
 - Set default for parameter `columns` in `peaksData,Spectra` and

--- a/R/peaks-functions.R
+++ b/R/peaks-functions.R
@@ -179,6 +179,8 @@ NULL
 #'
 #' Bin peaks of a spectrum.
 #'
+#' @param mids mid points. This parameter is mandatory.
+#'
 #' @inheritParams .peaks_remove
 #'
 #' @return `matrix` with columns `"mz"` and `"intensity"`
@@ -187,13 +189,15 @@ NULL
 .peaks_bin <- function(x, spectrumMsLevel, binSize = 1L,
                        breaks = seq(floor(min(x[, 1])),
                                     ceiling(max(x[, 1])),
-                                    by = binSize), FUN = sum,
+                                    by = binSize),
+                       agg_fun = sum,
+                       mids,
                        msLevel = spectrumMsLevel, ...) {
     if (!(spectrumMsLevel %in% msLevel))
         return(x)
     bins <- MsCoreUtils::bin(x[, 2], x[, 1], size = binSize, breaks = breaks,
-                             FUN = FUN)
-    cbind(mz = bins$mids, intensity = bins$x)
+                             FUN = agg_fun, returnMids = FALSE)
+    cbind(mz = mids, intensity = bins)
 }
 
 #' @importFrom stats quantile

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -349,7 +349,7 @@ estimatePrecursorIntensity(
 
 \S4method{reset}{Spectra}(object, ...)
 
-\S4method{bin}{Spectra}(x, binSize = 1L, breaks = NULL, msLevel. = unique(msLevel(x)))
+\S4method{bin}{Spectra}(x, binSize = 1L, breaks = NULL, msLevel. = unique(msLevel(x)), FUN = sum)
 
 \S4method{compareSpectra}{Spectra,Spectra}(
   x,
@@ -437,7 +437,9 @@ of each spectrum in \code{object}. For \code{compareSpectra}: function to compar
 intensities of peaks between two spectra with each other.
 For \code{combineSpectra}: function to combine the (peak matrices) of the
 spectra. See section \emph{Data manipulations} and examples below for more
-details.}
+details.
+For \code{bin}: function to aggregate intensity values of peaks falling into
+the same bin. Defaults to \code{FUN = sum} thus summing up intensities.}
 
 \item{y}{A \code{Spectra} object. A \code{DataFrame} for \code{joinSpectraData()}.}
 
@@ -1041,8 +1043,18 @@ write it back to the data storage. Parameter \code{f} allows to specify how
 equal to the \code{dataStorage}, or \code{f = rep(1, length(object))} to disable
 parallel processing alltogether. Other partitionings might result in
 errors (especially if a \code{MsBackendHdf5Peaks} backend is used).
-\item \code{bin}: aggregates individual spectra into discrete (m/z) bins. All
-intensity values for peaks falling into the same bin are summed.
+\item \code{bin}: aggregates individual spectra into discrete (m/z) bins. Binning is
+performed only on spectra of the specified MS level(s) (parameter
+\code{msLevel}, by default all MS levels of \code{x}). The bins can be defined with
+parameter \code{breaks} which by default are equally sized bins, with size
+being defined by parameter \code{binSize}, from the minimal to the maximal m/z
+of all spectra (of MS level \code{msLevel}) within \code{x}. The same bins are used
+for all spectra in \code{x}. All intensity values for peaks falling into the
+same bin are aggregated using the function provided with parameter \code{FUN}
+(defaults to \code{FUN = sum}, i.e. all intensities are summed up). Note that
+the binning operation is applied to the peak data on-the-fly upon data
+access and it is possible to \emph{revert} the operation with the \code{reset}
+function (see description of \code{reset} above).
 \item \code{combineSpectra}: combine sets of spectra into a single spectrum per set.
 For each spectrum group (set), spectra variables from the first spectrum
 are used and the peak matrices are combined using the function specified

--- a/man/hidden_aliases.Rd
+++ b/man/hidden_aliases.Rd
@@ -129,7 +129,8 @@ backendMerge(object, ...)
   y,
   size = 1,
   breaks = seq(floor(min(y)), ceiling(max(y)), by = size),
-  FUN = max
+  FUN = max,
+  returnMids = TRUE
 )
 
 containsMz(object, ...)

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1030,8 +1030,9 @@ test_that("bin,Spectra works", {
                      pks[sps$msLevel == 2])
 
     mzr <- range(unlist(mz(sps)))
-    brks <- seq(floor(mzr[1]), ceiling(mzr[2]), by = 2)
-    res1 <- bin(sps, msLevel = 1, binSize = 2, breaks = brks)
+    brks <- MsCoreUtils:::.fix_breaks(
+                              seq(floor(mzr[1]), ceiling(mzr[2]), by = 2), mzr)
+    res1 <- bin(sps, msLevel = 1, breaks = brks)
     res1_pks <- peaksData(res1)
     res_pks <- peaksData(res)
     expect_identical(res1_pks[res1$msLevel == 1],

--- a/tests/testthat/test_peaks-functions.R
+++ b/tests/testthat/test_peaks-functions.R
@@ -72,16 +72,33 @@ test_that(".peaks_bin works", {
              0, 1, 5, 10, 5, 1)
     x <- cbind(mz = 1:length(int), intensity = int)
 
-    res <- .peaks_bin(x, spectrumMsLevel = 1L)
-    expect_identical(res[, 2], x[, 2])
-    expect_identical(res[, 1], x[, 1] + 0.5)
+    brks <- seq(min(x), max(x), by = 1L)
+    brks <- MsCoreUtils:::.fix_breaks(brks, range(x))
+    mids <- seq_len(length(brks) -1)
+    res <- .peaks_bin(x, spectrumMsLevel = 1L, breaks = brks, mids = mids)
+    expect_identical(res[-1, 2], x[, 2])
+    expect_identical(res[, 1], as.numeric(mids))
 
-    res <- .peaks_bin(x, spectrumMsLevel = 1L, binSize = 2L)
-    expect_equal(res[, 2], c(1, 5, 1, 0, 1, 13, 8, 1, 3, 0, 6, 15, 1))
-    res <- .peaks_bin(x, spectrumMsLevel = 1L, binSize = 2L, FUN = max)
-    expect_equal(res[, 2], c(1, 3, 1, 0, 1, 10, 6, 1, 2, 0, 5, 10, 1))
+    brks <- seq(min(x), max(x), by = 2L)
+    brks <- MsCoreUtils:::.fix_breaks(brks, range(x))
+    mids <- (brks[-length(brks)] + brks[-1L]) / 2
+    res <- .peaks_bin(x, spectrumMsLevel = 1L, breaks = brks,
+                                mids = mids)
+    expect_equal(res[, 1], seq(1, 25, by = 2))
+    expect_equal(res[, 2], c(0, 3, 4, 0, 0, 4, 16, 3, 1, 2, 1, 15, 6))
+    res <- .peaks_bin(x, spectrumMsLevel = 1L, breaks = brks,
+                      agg_fun = max, mids = mids)
+    expect_equal(res[, 1], seq(1, 25, by = 2))
+    expect_equal(res[, 2], c(0, 2, 3, 0, 0, 3, 10, 2, 1, 2, 1, 10, 5))
     res <- .peaks_bin(x, spectrumMsLevel = 1L, msLevel = 2L, binSize = 2L)
     expect_identical(res, x)
+
+    brks <- seq(0.5, 30.5, by = 2)
+    mids <- seq((length(brks) - 1))
+    res <- Spectra:::.peaks_bin(x, breaks = brks, mids = mids,
+                                spectrumMsLevel = 1L)
+    expect_equal(res[, 1], mids)
+    expect_equal(res[, 2], c(1, 5, 1, 0, 1, 13, 8, 1, 3, 0, 6, 15, 1, 0, 0))
 })
 
 test_that("joinPeaks works", {

--- a/vignettes/Spectra.Rmd
+++ b/vignettes/Spectra.Rmd
@@ -233,13 +233,24 @@ intensity(sps)
 ```
 
 Peak data can also be extracted with the `peaksData` function that returns a
-list of matrices, each with columns `"mz"` and `"intensity"` containing the m/z
-and intensity values for one spectrum.
+list of numerical matrices with *peak variables* such as m/z and intensity
+values. Which peak variables are available in a `Spectra` object can be
+determined with the `peaksVariables` function.
+
+```{r}
+peaksVariables(sps)
+```
+
+These can be passed to the `peaksData` function with parameter `columns` to
+extract the peak variables of interest. By default `peaksData` extracts m/z and
+intensity values.
 
 ```{r peaks}
 pks <- peaksData(sps)
 pks[[1]]
 ```
+
+
 
 Note that we would get the same result by using the `as` method to coerce a
 `Spectra` object to a `list` or `SimpleList`:
@@ -494,14 +505,15 @@ Each spectrum in `sps_2` thus contains only a single peak. The parameter
 spectra variables that should be passed (in addition to the peaks matrix) to the
 user-provided function. This would enable for example to calculate *neutral
 loss* spectra from a `Spectra` by subtracting the precursor m/z from each m/z of
-a spectrum. Our tool example does not have precursor m/z values defined, thus we
-first set them to arbitrary values. Then we define a function `neutral_loss`
-that calculates the difference between the precursor m/z and the fragment peak's
-m/z. In addition we need to ensure the peaks in the resulting spectra are
-ordered by (the delta) m/z values. Note that, in order to be able to access the
-precursor m/z of the spectrum within our function, we have to add a parameter to
-the function that has the same name as the spectrum variable we want to access
-(in our case `precursorMz`).
+a spectrum (note that there would also be a dedicated `neutralLoss` function to
+perform this operation more efficiently). Our tool example does not have
+precursor m/z values defined, thus we first set them to arbitrary values. Then
+we define a function `neutral_loss` that calculates the difference between the
+precursor m/z and the fragment peak's m/z. In addition we need to ensure the
+peaks in the resulting spectra are ordered by (the delta) m/z values. Note that,
+in order to be able to access the precursor m/z of the spectrum within our
+function, we have to add a parameter to the function that has the same name as
+the spectrum variable we want to access (in our case `precursorMz`).
 
 ```{r set-precursor-mz}
 sps_rep$precursorMz <- c(150, 20, 30, 40)
@@ -767,6 +779,63 @@ The resulting matrix represents the result from the pairwise comparison. As
 expected, the first two and the last two spectra are similar, albeit only
 moderately while the spectra from 1-Methylhistidine don't share any similarity
 with those of Caffeine.
+
+Another way of comparing spectra would be to *bin* the spectra and to cluster
+them based on similar intensity values. Spectra binning ensures that the binned
+m/z values are comparable across all spectra. Below we bin our spectra using a
+bin size of 0.1 (i.e. all peaks with an m/z smaller than 0.1 are aggregated into
+one binned peak.
+
+```{r}
+sps_bin <- bin(sps, binSize = 0.1)
+```
+
+All spectra will now have the same number of m/z values.
+
+```{r}
+lengths(sps_bin)
+```
+
+Most of the intensity values for these will however be 0 (because in the
+original spectra no peak for the respective m/z bin was present).
+
+```{r}
+intensity(sps_bin)
+```
+
+We're next creating an intensity matrix for our `Spectra` object, each row being
+one spectrum and columns representing the binned m/z values.
+
+```{r}
+intmat <- do.call(rbind, intensity(sps_bin))
+```
+
+We can now identify those columns (m/z bins) with only 0s across all spectra and
+remove these.
+
+```{r}
+zeros <- colSums(intmat) == 0
+intmat <- intmat[, !zeros]
+intmat
+```
+
+The associated m/z values for the bins can be extracted with `mz` from the
+binned `Spectra` object. Below we use these as column names for the intensity
+matrix.
+
+```{r}
+colnames(intmat) <- mz(sps_bin)[[1L]][!zeros]
+```
+
+This intensity matrix could now for example be used to cluster the spectra based
+on their peak intensities.
+
+```{r}
+heatmap(intmat)
+```
+
+As expected, the first 2 and the last 2 spectra are more similar and are
+clustered together.
 
 
 ## Exporting spectra


### PR DESCRIPTION
- Expand documentation and vignette on the usage of the `bin,Spectra` method.
- `bin,Spectra` gains also parameter `FUN` to enable specifying the aggregation
  function.