### PR TITLE
fix: MsBackendMzR of lenght 0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.9.3
+Version: 1.9.4
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Spectra 1.9
 
+## Changes in 1.9.4
+
+- Fix error when extracting spectra variables from a `MsBackendMzR` of length 0.
+
 ## Changes in 1.9.3
 
 - Add `chunkapply` function to split a `Spectra` into chunks and stepwise apply

--- a/R/MsBackendMzR-functions.R
+++ b/R/MsBackendMzR-functions.R
@@ -96,22 +96,23 @@ MsBackendMzR <- function() {
 #' @noRd
 .spectra_data_mzR <- function(x, columns = spectraVariables(x)) {
     cn <- colnames(x@spectraData)
-    if(!nrow(x@spectraData)) {
-        res <- lapply(
-            .SPECTRA_DATA_COLUMNS[!(names(.SPECTRA_DATA_COLUMNS) %in%
-                                    c("mz", "intensity"))], do.call,
-            args = list())
-        res <- DataFrame(res)
-        res$mz <- NumericList(compress = FALSE)
-        res$intensity <- NumericList(compress = FALSE)
-        return(res[, columns, drop = FALSE])
-    }
     not_found <- setdiff(columns, c(cn, names(.SPECTRA_DATA_COLUMNS)))
     if (length(not_found))
         stop("Column(s) ", paste(not_found, collapse = ", "),
              " not available")
     sp_cols <- columns[columns %in% cn]
     res <- x@spectraData[, sp_cols, drop = FALSE]
+    if(!nrow(x@spectraData)) {
+        res$mz <- NumericList(compress = FALSE)
+        res$intensity <- NumericList(compress = FALSE)
+        other_cols <- setdiff(columns, c(sp_cols, "mz", "intensity"))
+        if (length(other_cols)) {
+            res_add <- lapply(.SPECTRA_DATA_COLUMNS[other_cols],
+                              do.call, args = list())
+            res <- cbind(res, res_add)
+        }
+        return(res[, columns, drop = FALSE])
+    }
     any_mz <- any(columns == "mz")
     any_int <- any(columns == "intensity")
     if (any_mz || any_int) {

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -2204,8 +2204,6 @@ setMethod("compareSpectra", signature(x = "Spectra", y = "missing"),
 
 ## normalize
 
-## peaksapply
-
 #' @rdname Spectra
 #'
 #' @exportMethod pickPeaks

--- a/tests/testthat/test_MsBackendMzR.R
+++ b/tests/testthat/test_MsBackendMzR.R
@@ -413,11 +413,11 @@ test_that("spectraData, spectraData<-, MsBackendMzR works", {
     res <- spectraData(be)
     expect_true(is(res, "DataFrame"))
     expect_true(nrow(res) == 0)
-    expect_true(all(names(Spectra:::.SPECTRA_DATA_COLUMNS) %in% colnames(res)))
+    expect_true(all(names(.SPECTRA_DATA_COLUMNS) %in% colnames(res)))
 
     tmp <- sciex_mzr
-    res <- Spectra:::.spectra_data_mzR(tmp)
-    expect_true(all(names(Spectra:::.SPECTRA_DATA_COLUMNS) %in% colnames(res)))
+    res <- .spectra_data_mzR(tmp)
+    expect_true(all(names(.SPECTRA_DATA_COLUMNS) %in% colnames(res)))
     expect_true(all(colnames(tmp@spectraData) %in% colnames(res)))
     expect_true(is.logical(res$smoothed))
     expect_equal(nrow(res), length(tmp))
@@ -440,6 +440,16 @@ test_that("spectraData, spectraData<-, MsBackendMzR works", {
     expect_true(is.logical(res$smoothed))
     expect_true(all(is.na(res$smoothed)))
 
+    ## Empty object.
+    tmp_sub <- tmp[integer()]
+    expect_identical(tmp_sub$new_col, numeric())
+    spd <- spectraData(tmp_sub, columns = c("msLevel", "rtime", "new_col"))
+    expect_true(nrow(spd) == 0)
+    expect_identical(spd$msLevel, integer())
+    expect_identical(spd$rtime, numeric())
+    expect_identical(spd$new_col, numeric())
+    expect_identical(tmp_sub$mz, IRanges::NumericList(compress = FALSE))
+
     spd <- spectraData(tmp, columns = c("msLevel", "rtime", "dataStorage"))
     expect_error(spectraData(tmp) <- spd, "scanIndex")
     spd <- spectraData(tmp, columns = c("msLevel", "rtime", "dataStorage",
@@ -448,6 +458,7 @@ test_that("spectraData, spectraData<-, MsBackendMzR works", {
     expect_true(all(is.na(centroided(tmp))))
     expect_true(all(is.na(polarity(tmp))))
     expect_equal(mz(tmp), mz(sciex_mzr))
+
 })
 
 test_that("show,MsBackendMzR works", {


### PR DESCRIPTION
- Fix error extracting spectra data from an `MsBackendMzR` of length 0.