### PR TITLE
fix: selectSpectraVariables,MsBackendMemory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.9.14
+Version: 1.9.15
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Spectra 1.9
 
+## Changes in 1.9.15
+
+- Fix issue in `MsBackendMemory` failed to return intensity or m/z values when
+  peaks data is empty.
+
 ## Changes in 1.9.14
 
 - Fix issue with `filterMzValues` that would only keep (or remove) the first

--- a/R/MsBackendMemory-functions.R
+++ b/R/MsBackendMemory-functions.R
@@ -7,9 +7,19 @@ MsBackendMemory <- function() {
 
 .df_pdata_column <- function(x, column) {
     idx <- which(colnames(x[[1L]]) == column)
-    if (length(idx)) {
+    if (length(idx))
         lapply(x, `[`, , j = idx)
-    } else stop("No peaks variable \"", column, "\" available")
+    else {
+        if (column %in% c("mz", "intensity"))
+            NumericList(vector("list", length(x)), compress = FALSE)
+        else stop("No peaks variable \"", column, "\" available")
+    }
+}
+
+.df_empty_peaks_data <- function(x) {
+    emat <- matrix(numeric(), ncol = 2, nrow = 0,
+                   dimnames = list(character(), c("mz", "intensity")))
+    replicate(x, emat, simplify = FALSE)
 }
 
 #' Check columns of a DataFrame or data.frame for their data type. If they

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -411,9 +411,11 @@ NULL
 #'
 #' - `selectSpectraVariables`: reduces the information within the object to
 #'   the selected spectra variables: all data for variables not specified will
-#'   be dropped. For mandatory columns (such as *msLevel*, *rtime* ...) only
-#'   the values will be dropped, while additional (user defined) spectra
-#'   variables will be completely removed. Returns the filtered `Spectra`.
+#'   be dropped. For mandatory columns (i.e., those listed by
+#'   [coreSpectraVariables()], such as *msLevel*, *rtime* ...) only
+#'   the values will be dropped but not the variable itself. Additional (or
+#'   user defined) spectra variables will be completely removed.
+#'   Returns the filtered `Spectra`.
 #'
 #' - `split`: splits the `Spectra` object based on parameter `f` into a `list`
 #'   of `Spectra` objects.
@@ -1785,13 +1787,15 @@ setMethod("scanIndex", "Spectra", function(object) {
 })
 
 #' @rdname Spectra
-setMethod("selectSpectraVariables", "Spectra",
-          function(object, spectraVariables = spectraVariables(object)) {
-              spectraVariables <- union(spectraVariables, "dataStorage")
-              object@backend <- selectSpectraVariables(
-                  object@backend, spectraVariables = spectraVariables)
-              object
-})
+setMethod(
+    "selectSpectraVariables", "Spectra",
+    function(object, spectraVariables = union(spectraVariables(object),
+                                              peaksVariables(object))) {
+        spectraVariables <- union(spectraVariables, "dataStorage")
+        object@backend <- selectSpectraVariables(
+            object@backend, spectraVariables = spectraVariables)
+        object
+    })
 
 #' @rdname Spectra
 setMethod("smoothed", "Spectra", function(object) {

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -265,7 +265,10 @@ estimatePrecursorIntensity(
 
 \S4method{scanIndex}{Spectra}(object)
 
-\S4method{selectSpectraVariables}{Spectra}(object, spectraVariables = spectraVariables(object))
+\S4method{selectSpectraVariables}{Spectra}(
+  object,
+  spectraVariables = union(spectraVariables(object), peaksVariables(object))
+)
 
 \S4method{smoothed}{Spectra}(object)
 
@@ -1004,9 +1007,11 @@ data filtering operations. Note that a \code{reset} call after \code{applyProces
 will not have any effect. See examples below for more information.
 \item \code{selectSpectraVariables}: reduces the information within the object to
 the selected spectra variables: all data for variables not specified will
-be dropped. For mandatory columns (such as \emph{msLevel}, \emph{rtime} ...) only
-the values will be dropped, while additional (user defined) spectra
-variables will be completely removed. Returns the filtered \code{Spectra}.
+be dropped. For mandatory columns (i.e., those listed by
+\code{\link[=coreSpectraVariables]{coreSpectraVariables()}}, such as \emph{msLevel}, \emph{rtime} ...) only
+the values will be dropped but not the variable itself. Additional (or
+user defined) spectra variables will be completely removed.
+Returns the filtered \code{Spectra}.
 \item \code{split}: splits the \code{Spectra} object based on parameter \code{f} into a \code{list}
 of \code{Spectra} objects.
 \item \code{joinSpectraData}: Individual spectra variables can be directly

--- a/tests/testthat/test_MsBackendMemory.R
+++ b/tests/testthat/test_MsBackendMemory.R
@@ -841,6 +841,7 @@ test_that("backendMerge,MsBackendMemory works", {
 
 test_that("selectSpectraVariables,MsBackendMemory works", {
     be <- MsBackendMemory()
+    expect_equal(peaksVariables(be), c("mz", "intensity"))
     expect_error(selectSpectraVariables(be, c("msLevel", "other")),
                  "not available")
 
@@ -848,11 +849,20 @@ test_that("selectSpectraVariables,MsBackendMemory works", {
     expect_error(selectSpectraVariables(be, c("msLevel")), "dataStorage")
     res <- selectSpectraVariables(be, c("msLevel", "dataStorage"))
     expect_equal(colnames(res@spectraData), c("msLevel", "dataStorage"))
-    expect_equal(peaksVariables(res), NULL)
+    expect_equal(peaksVariables(res), c("mz", "intensity"))
+    expect_s4_class(intensity(res), "NumericList")
+    expect_s4_class(mz(res), "NumericList")
+    expect_true(length(res@peaksData) == 3)
+    expect_true(all(vapply(res@peaksData, is.matrix, logical(1))))
+    expect_true(all(vapply(res@peaksData, nrow, integer(1)) == 0))
 
     res <- selectSpectraVariables(be, c("mz", "dataStorage"))
     expect_equal(colnames(res@spectraData), c("dataStorage"))
     expect_equal(peaksVariables(res), "mz")
+    expect_equal(mz(res), mz(be))
+    expect_s4_class(intensity(res), "NumericList")
+    expect_equal(length(intensity(res)), length(mz(res)))
+    expect_true(all(lengths(intensity(res)) == 0))
 
     tmp <- test_df
     tmp$peak_anno <- list(c("a", "", "b"), c("a", "b"), c("a", "b", "c", "d"))

--- a/vignettes/MsBackend.Rmd
+++ b/vignettes/MsBackend.Rmd
@@ -1230,9 +1230,10 @@ implementation for our backend will remove any columns in the `@spectraVars`
 data frame not defined in the `spectraVariables` parameter. Special care is
 given to the `"mz"` and `"intensity"` spectra variables: if they are not
 selected, the `@mz` and `@intensity` slots are initialized with empty
-`NumericList` (of length matching the number of spectra). Note also that it
-might not be allowed to remove spectra variables
-some backends might have spectra variables that are not
+`NumericList` (of length matching the number of spectra). Note also that some
+backends might throw an error if a spectra variable required for the backend is
+removed (such as `"dataStorage"` for a `MsBackendMzR` backend, which is
+required by the backend to allow retrieval of m/z and intensity values).
 
 ```{r}
 setMethod(


### PR DESCRIPTION
- Fix `selectSpectraVariables,MsBackendMemory`: return values for *core* spectra variables `"mz"` and `"intensity"` even if they are not in peaks data.