### PR TITLE
feat: add a function to coerce from Spectra to MSnbase::MSpectra

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.15.7
+Version: 1.15.8
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different
@@ -66,6 +66,8 @@ Suggests:
     vdiffr (>= 1.0.0),
     msentropy,
     patrick
+Enhances:
+    MSnbase
 License: Artistic-2.0
 LazyData: false
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Spectra 1.15
 
+## Changes in 1.15.8
+
+- Add backward compatibility by supporting to change from a `Spectra` to a
+  *MSnbase* `MSpectra` object using `as()`.
+
 ## Changes in 1.15.7
 
 - Change `estimatePrecursorIntensity()` to a method to avoid overrides/clashes

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -6,6 +6,7 @@ NULL
 #' @aliases Spectra-class [,Spectra-method
 #' @aliases uniqueMsLevels uniqueMsLevels,Spectra-method
 #' @aliases combinePeaks
+#' @aliases msLevel
 #'
 #' @name Spectra
 #'
@@ -54,6 +55,7 @@ NULL
 #'   the `acquisitionNum`)
 #'
 #' See also [this issue](https://github.com/lgatto/MSnbase/issues/525).
+#'
 #'
 #' @section Creation of objects, conversion, changing the backend and export:
 #'
@@ -145,6 +147,7 @@ NULL
 #' the original data files. Thus, for `Spectra` objects (using this backend)
 #' that were moved to another file system or computer, these functions allow to
 #' adjust/adapt the base file path.
+#'
 #'
 #' @section Accessing spectra data:
 #'
@@ -330,6 +333,7 @@ NULL
 #'
 #' - `uniqueMsLevels()`: get the unique MS levels available in `object`. This
 #'   function is supposed to be more efficient than `unique(msLevel(object))`.
+#'
 #'
 #' @section Filter spectra data:
 #'
@@ -797,6 +801,13 @@ NULL
 #'   ranges of successive non-0 peaks <= `threshold` are set to 0.
 #'   Parameter `msLevel.` allows to apply this to only spectra of certain MS
 #'   level(s).
+#'
+#'
+#' @section Backward compatibility:
+#'
+#' `Spectra` objects can be coerced to the older `MSpectra` objects from the
+#' *MSnbase* package using the `as()` function (e.g. `as(sps, "MSpectra")`
+#' where `sps` is a `Spectra` object).
 #'
 #'
 #' @return See individual method description for the return value.
@@ -1786,6 +1797,10 @@ setAs("Spectra", "list", function(from, to) {
 
 setAs("Spectra", "SimpleList", function(from, to) {
     peaksData(from)
+})
+
+setAs("Spectra", "MSpectra", function(from) {
+    MSnbase::MSpectra(.spectra_to_spectrum_list(from, chunkSize = 1000))
 })
 
 #' @rdname Spectra

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -18,6 +18,7 @@
 \alias{uniqueMsLevels}
 \alias{uniqueMsLevels,Spectra-method}
 \alias{combinePeaks}
+\alias{msLevel}
 \alias{Spectra,missing-method}
 \alias{Spectra,MsBackend-method}
 \alias{Spectra,character-method}
@@ -1565,6 +1566,14 @@ ranges of successive non-0 peaks <= \code{threshold} are set to 0.
 Parameter \code{msLevel.} allows to apply this to only spectra of certain MS
 level(s).
 }
+}
+
+\section{Backward compatibility}{
+
+
+\code{Spectra} objects can be coerced to the older \code{MSpectra} objects from the
+\emph{MSnbase} package using the \code{as()} function (e.g. \code{as(sps, "MSpectra")}
+where \code{sps} is a \code{Spectra} object).
 }
 
 \examples{

--- a/tests/testthat/test_Spectra-functions.R
+++ b/tests/testthat/test_Spectra-functions.R
@@ -923,3 +923,13 @@ test_that("filterPeaksRanges,Spectra works", {
     a <- peaksData(res)[[2L]]
     expect_true(nrow(a) == 0)
 })
+
+test_that(".spectra_to_spectrum_list works", {
+    ## With MSnbase in Enhances we would need to call it like below.
+    if (requireNamespace("MSnbase", quietly = TRUE)) {
+        ## library(MSnbase) # MSnbase needs to be in Suggests
+        a <- .spectra_to_spectrum_list(sps_dda, chunkSize = 5000)
+        expect_true(is.list(a))
+        expect_equal(length(a), length(sps_dda))
+    }
+})

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1939,3 +1939,13 @@ test_that("estimatePrecursorIntensity works", {
     res_both <- estimatePrecursorIntensity(both)
     expect_equal(res_second, res_both[510:length(res_both)])
 })
+
+test_that("coersion from Spectra to MSpectra works", {
+    ## With MSnbase in Enhances we would need to call it like below
+    if (requireNamespace("MSnbase", quietly = TRUE)) {
+        ## library(MSnbase) # MSnbase needs to be in Suggests
+        a <- as(sps_dda, "MSpectra")
+        expect_s4_class(a, "MSpectra")
+        expect_equal(unname(msLevel(a)), msLevel(sps_dda))
+    }
+})


### PR DESCRIPTION
- Add backward compatibility: support changing from a `Spectra` object to a `MSnbase::MSpectra` object using the `as()` method.
- Add unit tests conditional to the installation of the *MSnbase* package.