### PR TITLE
Improve and fix the Spectra constructor method

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,7 @@
 ^\.github$
 .editorconfig
 .travis.yml
+man/figures*
 local_data
 favicon
 logo.png

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.15.7
+Version: 1.15.8
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Spectra 1.15
 
+## Changes in 1.15.8
+
+- Refactor the `Spectra()` constructor method: better support for
+  initialization of backends that define their own specific parameters.
+
 ## Changes in 1.15.7
 
 - Change `estimatePrecursorIntensity()` to a method to avoid overrides/clashes

--- a/R/MsBackendMzR.R
+++ b/R/MsBackendMzR.R
@@ -43,12 +43,14 @@ setValidity("MsBackendMzR", function(object) {
 #' @importFrom BiocParallel bpparam
 setMethod("backendInitialize", "MsBackendMzR",
           function(object, files, ..., BPPARAM = bpparam()) {
-              if (missing(files) || !length(files))
+              if (missing(files))
                   stop("Parameter 'files' is mandatory for 'MsBackendMzR'")
               if (!is.character(files))
                   stop("Parameter 'files' is expected to be a character vector",
                        " with the files names from where data should be",
                        " imported")
+              if (!length(files))
+                  return(object)
               files <- normalizePath(files, mustWork = FALSE)
               msg <- .valid_ms_backend_files_exist(files)
               if (length(msg))


### PR DESCRIPTION
Update the `Spectra()` constructor method to better support initialization with backends defining their own specific parameters. This also fixes https://github.com/rformassspectrometry/MsBackendMetaboLights/issues/4