### PR TITLE
feat: add parameter return.type to peaksData

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Cache R packages
         if: "!contains(github.event.head_commit.message, '/nocache') && runner.os != 'Linux'"
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ env.cache-version }}-${{ runner.os }}-biocversion-devel-r-devel-${{ hashFiles('.github/depends.Rds') }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Cache R packages on Linux
         if: "!contains(github.event.head_commit.message, '/nocache') && runner.os == 'Linux' "
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/_temp/Library
           key: ${{ env.cache-version }}-${{ runner.os }}-biocversion-devel-r-devel-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -40,7 +40,7 @@ env:
   run_pkgdown: 'true'
   has_RUnit: 'false'
   has_BiocCheck: 'false'
-  cache-version: 'cache-v1'
+  cache-version: 'cache-v4'
 
 jobs:
   build-check:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.17.7
+Version: 1.17.8
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Spectra 1.17
 
+## Change in 1.17.8
+
+- Add parameter `return.type` to `peaksData()`.
+
 ## Change in 1.17.7
 
 - Add the `spectraVariableMapping<-` generic method.

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -639,6 +639,10 @@ setReplaceMethod("dataStorageBasePath", "Spectra", function(object, value) {
 #'
 #' @param object A `Spectra` object.
 #'
+#' @param return.type For `peaksData()`: `character(1)` allowing to specify if
+#'     the results should be returned as a `SimpleList` or as a `list`.
+#'     Defaults to `return.type = "SimpleList"`.
+#'
 #' @param spectraVars `character()` indicating what spectra variables to add to
 #'     the `DataFrame`. Default is `spectraVariables(object)`, i.e. all
 #'     available variables.
@@ -1203,10 +1207,19 @@ setMethod("mz", "Spectra", function(object, f = processingChunkFactor(object),
 setMethod(
     "peaksData", "Spectra",
     function(object, columns = c("mz", "intensity"),
-             f = processingChunkFactor(object), ..., BPPARAM = bpparam()) {
+             f = processingChunkFactor(object),
+             return.type = c("SimpleList", "list"), ..., BPPARAM = bpparam()) {
+        return.type <- match.arg(return.type)
         if (length(object@processingQueue) || length(f))
-            SimpleList(.peaksapply(object, columns = columns, f = f))
-        else SimpleList(peaksData(object@backend, columns = columns))
+            switch(return.type,
+                   SimpleList = SimpleList(
+                       .peaksapply(object, columns = columns, f = f)),
+                   list = .peaksapply(object, columns = columns, f = f))
+        else
+            switch(return.type,
+                   SimpleList = SimpleList(
+                       peaksData(object@backend, columns = columns)),
+                   list = peaksData(object@backend, columns = columns))
     })
 
 #' @rdname spectraData

--- a/man/spectraData.Rd
+++ b/man/spectraData.Rd
@@ -137,6 +137,7 @@ coreSpectraVariables()
   object,
   columns = c("mz", "intensity"),
   f = processingChunkFactor(object),
+  return.type = c("SimpleList", "list"),
   ...,
   BPPARAM = bpparam()
 )
@@ -219,6 +220,10 @@ For \code{peaksData()} accessor: optional \code{character} with requested column
 in the individual \code{matrix} of the returned \code{list}. Defaults to
 \code{c("mz", "value")} but any values returned by \code{peaksVariables(object)}
 with \code{object} being the \code{Spectra} object are supported.}
+
+\item{return.type}{For \code{peaksData()}: \code{character(1)} allowing to specify if
+the results should be returned as a \code{SimpleList} or as a \code{list}.
+Defaults to \code{return.type = "SimpleList"}.}
 
 \item{BPPARAM}{Parallel setup configuration. See \code{\link[BiocParallel:register]{BiocParallel::bpparam()}}
 for more information. See also \code{\link[=processingChunkSize]{processingChunkSize()}} for more

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -2090,3 +2090,11 @@ test_that("applyProcessing works", {
 
     expect_error(applyProcessing(sps_mem, f = 1:2), "has to be equal to the")
 })
+
+test_that("peaksData,Spectra works ", {
+    a <- sps_dda[1:3]
+    res <- peaksData(a)
+    expect_s4_class(res, "SimpleList")
+    res <- peaksData(a, return.type = "list")
+    expect_true(is.list(res))
+})


### PR DESCRIPTION
This PR adds a new parameter `return.type` to `peaksData()`. With `return.type = "list"` the data would not be converted first to a `SimpleList` which has performance advantages (avoids copying of the data, but also operations such as `split()` etc are faster on a `list` than on a `SimpleList`). Thus, we might set `return.type = "list"` in other packages such as *xcms*.