### PR TITLE
refactor: filterRt to support msLevel. = integer()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.17.8
+Version: 1.17.9
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Spectra 1.17
 
+## Change in 1.17.9
+
+- Allow parameter `msLevel. = integer()` for `filterRt()` to filter spectra of
+  **all** MS levels. This was `msLevel. = uniqueMsLevels()`, which, depending
+  on the backend, can be computationally intense. Add related unit tests to
+  the unit test suite.
+
 ## Change in 1.17.8
 
 - Add parameter `return.type` to `peaksData()`.

--- a/R/MsBackend.R
+++ b/R/MsBackend.R
@@ -448,7 +448,8 @@
 #'    for `MsBackend` is available.
 #'
 #' - `filterRt()`: retains spectra of MS level `msLevel` with retention times
-#'    within (`>=`) `rt[1]` and (`<=`) `rt[2]`.
+#'    within (`>=`) `rt[1]` and (`<=`) `rt[2]`. The filter is applied to all
+#'    spectra if no MS level is specified (the default, `msLevel. = integer()`).
 #'    Implementation of this method is optional since a default implementation
 #'    for `MsBackend` is available.
 #'
@@ -1421,12 +1422,17 @@ setMethod("filterRanges", "MsBackend",
 #'
 #' @export
 setMethod("filterRt", "MsBackend",
-          function(object, rt = numeric(), msLevel. = uniqueMsLevels(object)) {
+          function(object, rt = numeric(), msLevel. = integer()) {
               if (length(rt)) {
                   rt <- range(rt)
-                  sel_ms <- msLevel(object) %in% msLevel.
-                  sel_rt <- between(rtime(object), rt) & sel_ms
-                  object[sel_rt | !sel_ms]
+                  if (length(msLevel.)) {
+                      sel_ms <- msLevel(object) %in% msLevel.
+                      sel_rt <- between(rtime(object), rt) & sel_ms
+                      object[sel_rt | !sel_ms]
+                  } else {
+                      sel_rt <- between(rtime(object), rt)
+                      object[sel_rt]
+                  }
               } else object
           })
 

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -1995,8 +1995,9 @@ setMethod("combinePeaks", "Spectra", function(object, tolerance = 0, ppm = 20,
 #'
 #' - `filterRt()`: retains spectra of MS level `msLevel` with retention
 #'   times (in seconds) within (`>=`) `rt[1]` and (`<=`)
-#'   `rt[2]`. Returns the filtered `Spectra` (with spectra in their
-#'   original order).
+#'   `rt[2]`. This retention time filter is applied to all spectra (regardless
+#'   of their MS level) if `msLevel. = integer()` (the default). Returns the
+#'   filtered `Spectra` (with spectra in their original order).
 #'
 #' - `filterValues()`: allows filtering of the `Spectra` object based on
 #'   similarities of *numeric* values of one or more `spectraVariables(object)`
@@ -2741,7 +2742,7 @@ setMethod("filterPrecursorScan", "Spectra",
 
 #' @rdname filterMsLevel
 setMethod("filterRt", "Spectra",
-          function(object, rt = numeric(), msLevel. = uniqueMsLevels(object)) {
+          function(object, rt = numeric(), msLevel. = integer()) {
               if (!is.numeric(msLevel.))
                   stop("Please provide a numeric MS level.")
               if (length(rt) != 2L || !is.numeric(rt) || rt[1] >= rt[2])

--- a/inst/test_backends/test_MsBackend/test_spectra_subsetting.R
+++ b/inst/test_backends/test_MsBackend/test_spectra_subsetting.R
@@ -141,3 +141,31 @@ test_that("filterDataOrigin", {
         expect_equal(a, b)
     }
 })
+
+#' If `msLevel.` is not provided or if it maches all unique MS levels the
+#' filter should be applied to all spectra, otherwise to only the spectra of
+#' the MS level.
+test_that("filterRt works", {
+    ref <- getMethod("filterRt", "MsBackend")
+    rtr <- range(rtime(be))
+    rtr <- range(c(rtr[1L] * 2, rtr[2L] / 2))
+    res_ref <- ref(be, rtr, msLevel. = integer())
+    res <- filterRt(be, rtr, msLevel. = integer())
+    expect_equal(length(res_ref), length(res))
+    expect_equal(rtime(res_ref), rtime(res))
+
+    res_ref <- ref(be, rtr, msLevel. = unique(msLevel(be)))
+    res <- filterRt(be, rtr, msLevel. = unique(msLevel(be)))
+    expect_equal(length(res_ref), length(res))
+    expect_equal(rtime(res_ref), rtime(res))
+
+    res_ref <- ref(be, rtr, msLevel. = 1L)
+    res <- filterRt(be, rtr, msLevel. = 1L)
+    expect_equal(length(res_ref), length(res))
+    expect_equal(rtime(res_ref), rtime(res))
+
+    res_ref <- ref(be, rtr, msLevel. = 2L)
+    res <- filterRt(be, rtr, msLevel. = 2L)
+    expect_equal(length(res_ref), length(res))
+    expect_equal(rtime(res_ref), rtime(res))
+})

--- a/man/MsBackend.Rd
+++ b/man/MsBackend.Rd
@@ -190,7 +190,7 @@
   match = c("all", "any")
 )
 
-\S4method{filterRt}{MsBackend}(object, rt = numeric(), msLevel. = uniqueMsLevels(object))
+\S4method{filterRt}{MsBackend}(object, rt = numeric(), msLevel. = integer())
 
 \S4method{filterValues}{MsBackend}(
   object,
@@ -720,7 +720,8 @@ values are within any of the provided ranges are retained).
 Implementation of this method is optional since a default implementation
 for \code{MsBackend} is available.
 \item \code{filterRt()}: retains spectra of MS level \code{msLevel} with retention times
-within (\code{>=}) \code{rt[1]} and (\code{<=}) \code{rt[2]}.
+within (\code{>=}) \code{rt[1]} and (\code{<=}) \code{rt[2]}. The filter is applied to all
+spectra if no MS level is specified (the default, \code{msLevel. = integer()}).
 Implementation of this method is optional since a default implementation
 for \code{MsBackend} is available.
 \item \code{filterValues()}: allows filtering of the \code{Spectra} object based on

--- a/man/filterMsLevel.Rd
+++ b/man/filterMsLevel.Rd
@@ -146,7 +146,7 @@ filterPrecursorPeaks(
 
 \S4method{filterPrecursorScan}{Spectra}(object, acquisitionNum = integer(), f = dataOrigin(object))
 
-\S4method{filterRt}{Spectra}(object, rt = numeric(), msLevel. = uniqueMsLevels(object))
+\S4method{filterRt}{Spectra}(object, rt = numeric(), msLevel. = integer())
 
 \S4method{filterRanges}{Spectra}(
   object,
@@ -407,8 +407,9 @@ any of the conditions must match (\code{match = "any"}; all spectra for which
 values are within any of the provided ranges are retained).
 \item \code{filterRt()}: retains spectra of MS level \code{msLevel} with retention
 times (in seconds) within (\code{>=}) \code{rt[1]} and (\code{<=})
-\code{rt[2]}. Returns the filtered \code{Spectra} (with spectra in their
-original order).
+\code{rt[2]}. This retention time filter is applied to all spectra (regardless
+of their MS level) if \code{msLevel. = integer()} (the default). Returns the
+filtered \code{Spectra} (with spectra in their original order).
 \item \code{filterValues()}: allows filtering of the \code{Spectra} object based on
 similarities of \emph{numeric} values of one or more \code{spectraVariables(object)}
 (parameter \code{spectraVariables}) to provided values (parameter \code{values})

--- a/tests/testthat/test_MsBackendMemory.R
+++ b/tests/testthat/test_MsBackendMemory.R
@@ -979,3 +979,27 @@ test_that("backendRequiredSpectraVariables,MsBackendMemory works", {
     expect_equal(backendRequiredSpectraVariables(MsBackendMemory()),
                  "dataStorage")
 })
+
+test_that("filterRt works for MsBackendMemory", {
+    test_df$rtime <- c(1.2, 2.1, 3.1)
+    be <- backendInitialize(MsBackendMemory(), test_df)
+    res <- filterRt(be, c(1, 2))
+    expect_equal(length(res), 1L)
+    expect_equal(rtime(res), 1.2)
+
+    res <- filterRt(be, c(1, 2), integer())
+    expect_equal(length(res), 1L)
+    expect_equal(rtime(res), 1.2)
+
+    res <- filterRt(be, c(1, 2), 1:4)
+    expect_equal(length(res), 1L)
+    expect_equal(rtime(res), 1.2)
+
+    res <- filterRt(be, c(1, 2), 2L)
+    expect_equal(length(res), 1L)
+    expect_equal(rtime(res), 1.2)
+
+    res <- filterRt(be, c(1, 3), 2L)
+    expect_equal(length(res), 2L)
+    expect_equal(rtime(res), c(1.2, 2.1))
+})

--- a/vignettes/MsBackend.Rmd
+++ b/vignettes/MsBackend.Rmd
@@ -1993,7 +1993,7 @@ a different MS level are returned as well). The default implementation for
 
 ```{r}
 setMethod("filterRt", "MsBackend",
-          function(object, rt = numeric(), msLevel. = uniqueMsLevels(object)) {
+          function(object, rt = numeric(), msLevel. = integer()) {
               if (length(rt)) {
                   rt <- range(rt)
                   sel_ms <- msLevel(object) %in% msLevel.


### PR DESCRIPTION
- Applying the retention time filter of `filterRt()` to **all** spectra when `msLevel. = integer()` is used.