### PR TITLE
fix `BPPARAM` parameter passing in `peaksData()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.19.2
+Version: 1.19.3
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.19.3
+Version: 1.19.4
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Spectra 1.19
 
+## Change in 1.19.3
+
+- Fix passing of `BPPARAM` parameter in `peaksData()` method for `Spectra`. 
+  Now is being passed down to `.peaksapply()`.  
+
 ## Change in 1.19.2
 
 - Fix export of data using `MsBackendMzR`: save also the precursor scan number
@@ -35,7 +40,6 @@
 
 - Add new `fillCoreSpectraVariables()` function that allows to add eventually
   missing *core* spectra variables (with the correct data type) to a data frame.
-
 
 ## Change in 1.17.5
 

--- a/R/Spectra.R
+++ b/R/Spectra.R
@@ -433,8 +433,7 @@ setMethod("Spectra", "missing", function(object, processingQueue = list(),
 
 #' @rdname Spectra
 setMethod("Spectra", "MsBackend", function(object, processingQueue = list(),
-                                           metadata = list(), ...,
-                                           BPPARAM = bpparam()) {
+                                           metadata = list(), ...) {
     new("Spectra", metadata = metadata, processingQueue = processingQueue,
         backend = object)
 })
@@ -1213,8 +1212,10 @@ setMethod(
         if (length(object@processingQueue) || length(f))
             switch(return.type,
                    SimpleList = SimpleList(
-                       .peaksapply(object, columns = columns, f = f)),
-                   list = .peaksapply(object, columns = columns, f = f))
+                       .peaksapply(object, columns = columns, f = f,
+                                   BPPARAM = backendBpparam(object, BPPARAM))),
+                   list = .peaksapply(object, columns = columns, f = f,
+                                    BPPARAM = backendBpparam(object, BPPARAM)))
         else
             switch(return.type,
                    SimpleList = SimpleList(

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -24,13 +24,7 @@
   BPPARAM = bpparam()
 )
 
-\S4method{Spectra}{MsBackend}(
-  object,
-  processingQueue = list(),
-  metadata = list(),
-  ...,
-  BPPARAM = bpparam()
-)
+\S4method{Spectra}{MsBackend}(object, processingQueue = list(), metadata = list(), ...)
 
 \S4method{Spectra}{character}(
   object,


### PR DESCRIPTION
The parallelization should work better now ! 

Also removed it in a function definition as it was not and could not be passed down. 