### PR TITLE
Add default implementation for replacement methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Spectra
 Title: Spectra Infrastructure for Mass Spectrometry Data
-Version: 1.19.7
+Version: 1.19.8
 Description: The Spectra package defines an efficient infrastructure
    for storing and handling mass spectrometry spectra and functionality to
    subset, process, visualize and compare spectra data. It provides different

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Spectra 1.19
 
+## Change 1.19.8
+
+- Add default implementations for `MsBackend` for replacement methods
+  `centroided<-`, `collisionEnergy<-`, `dataOrigin<-`,
+  `isolationWindowLowerMz<-`, `isolationWindowTargetMz<-`,
+  `isolationWindowUpperMz<-`, `msLevel<-`, `polarity<-`, `precursorMz<-`,
+  `rtime<-` and `smoothed<-`. This reduces the amount of methods required to be
+  implemented for new `MsBackend` classes.
+
 ## Change 1.19.7
 
 - Add `longForm,MsBackend` and `longForm,Spectra` methods (issue

--- a/R/MsBackend.R
+++ b/R/MsBackend.R
@@ -1096,7 +1096,8 @@ setMethod("centroided", "MsBackend", function(object) {
 #'
 #' @export
 setReplaceMethod("centroided", "MsBackend", function(object, value) {
-    stop("Not implemented for ", class(object), ".")
+    object$centroided <- value
+    object
 })
 
 #' @exportMethod collisionEnergy
@@ -1118,7 +1119,8 @@ setMethod("collisionEnergy", "MsBackend", function(object) {
 #'
 #' @export
 setReplaceMethod("collisionEnergy", "MsBackend", function(object, value) {
-    stop("Not implemented for ", class(object), ".")
+    object$collisionEnergy <- value
+    object
 })
 
 #' @exportMethod dataOrigin
@@ -1140,7 +1142,8 @@ setMethod("dataOrigin", "MsBackend", function(object) {
 #'
 #' @export
 setReplaceMethod("dataOrigin", "MsBackend", function(object, value) {
-    stop("Not implemented for ", class(object), ".")
+    object$dataOrigin <- value
+    object
 })
 
 #' @exportMethod dataStorage
@@ -1575,10 +1578,11 @@ setMethod("isolationWindowLowerMz", "MsBackend", function(object) {
 #' @rdname MsBackend
 #'
 #' @export
-setReplaceMethod("isolationWindowLowerMz", "MsBackend", function(object,
-                                                                 value) {
-    stop("Not implemented for ", class(object), ".")
-})
+setReplaceMethod("isolationWindowLowerMz", "MsBackend",
+                 function(object, value) {
+                     object$isolationWindowLowerMz <- value
+                     object
+                 })
 
 #' @exportMethod isolationWindowTargetMz
 #'
@@ -1598,10 +1602,11 @@ setMethod("isolationWindowTargetMz", "MsBackend", function(object) {
 #' @rdname MsBackend
 #'
 #' @export
-setReplaceMethod("isolationWindowTargetMz", "MsBackend", function(object,
-                                                                  value) {
-    stop("Not implemented for ", class(object), ".")
-})
+setReplaceMethod("isolationWindowTargetMz", "MsBackend",
+                 function(object, value) {
+                     object$isolationWindowTargetMz <- value
+                     object
+                 })
 
 #' @exportMethod isolationWindowUpperMz
 #'
@@ -1621,10 +1626,11 @@ setMethod("isolationWindowUpperMz", "MsBackend", function(object) {
 #' @rdname MsBackend
 #'
 #' @export
-setReplaceMethod("isolationWindowUpperMz", "MsBackend", function(object,
-                                                                 value) {
-    stop("Not implemented for ", class(object), ".")
-})
+setReplaceMethod("isolationWindowUpperMz", "MsBackend",
+                 function(object, value) {
+                     object$isolationWindowUpperMz <- value
+                     object
+                 })
 
 #' @exportMethod isReadOnly
 #'
@@ -1663,7 +1669,8 @@ setMethod("msLevel", "MsBackend", function(object) {
 #'
 #' @export
 setReplaceMethod("msLevel", "MsBackend", function(object, value) {
-    stop("Not implemented for ", class(object), ".")
+    object$msLevel <- as.integer(value)
+    object
 })
 
 #' @exportMethod mz
@@ -1712,7 +1719,9 @@ setMethod("polarity", "MsBackend", function(object) {
 #'
 #' @export
 setReplaceMethod("polarity", "MsBackend", function(object, value) {
-    stop("Not implemented for ", class(object), ".")
+    if (is.numeric(value)) value <- as.integer(value)
+    object$polarity <- value
+    object
 })
 
 #' @exportMethod precScanNum
@@ -1810,7 +1819,8 @@ setMethod("rtime", "MsBackend", function(object) {
 #'
 #' @export
 setReplaceMethod("rtime", "MsBackend", function(object, value) {
-    stop("Not implemented for ", class(object), ".")
+    object$rtime <- value
+    object
 })
 
 #' @exportMethod scanIndex
@@ -1856,7 +1866,8 @@ setMethod("smoothed", "MsBackend", function(object) {
 #'
 #' @export
 setReplaceMethod("smoothed", "MsBackend", function(object, value) {
-    stop("Not implemented for ", class(object), ".")
+    object$smoothed <- value
+    object
 })
 
 #' @exportMethod spectraData

--- a/R/MsBackendCached.R
+++ b/R/MsBackendCached.R
@@ -443,31 +443,13 @@ setMethod("centroided", "MsBackendCached", function(object) {
 })
 
 #' @rdname MsBackendCached
-setReplaceMethod("centroided", "MsBackendCached", function(object, value) {
-    object$centroided <- value
-    object
-})
-
-#' @rdname MsBackendCached
 setMethod("collisionEnergy", "MsBackendCached", function(object) {
     spectraData(object, "collisionEnergy")[, 1]
 })
 
 #' @rdname MsBackendCached
-setReplaceMethod("collisionEnergy", "MsBackendCached", function(object, value) {
-    object$collisionEnergy <- value
-    object
-})
-
-#' @rdname MsBackendCached
 setMethod("dataOrigin", "MsBackendCached", function(object) {
     spectraData(object, "dataOrigin")[, 1]
-})
-
-#' @rdname MsBackendCached
-setReplaceMethod("dataOrigin", "MsBackendCached", function(object, value) {
-    object$dataOrigin <- value
-    object
 })
 
 #' @rdname MsBackendCached
@@ -500,35 +482,14 @@ setMethod("isolationWindowLowerMz", "MsBackendCached", function(object) {
 })
 
 #' @rdname MsBackendCached
-setReplaceMethod("isolationWindowLowerMz", "MsBackendCached",
-                 function(object, value) {
-                     object$isolationWindowLowerMz <- value
-                     object
-                 })
-
-#' @rdname MsBackendCached
 setMethod("isolationWindowTargetMz", "MsBackendCached", function(object) {
     spectraData(object, "isolationWindowTargetMz")[, 1]
 })
 
 #' @rdname MsBackendCached
-setReplaceMethod("isolationWindowTargetMz", "MsBackendCached",
-                 function(object, value) {
-                     object$isolationWindowTargetMz <- value
-                     object
-                 })
-
-#' @rdname MsBackendCached
 setMethod("isolationWindowUpperMz", "MsBackendCached", function(object) {
     spectraData(object, "isolationWindowUpperMz")[, 1]
 })
-
-#' @rdname MsBackendCached
-setReplaceMethod("isolationWindowUpperMz", "MsBackendCached",
-                 function(object, value) {
-                     object$isolationWindowUpperMz <- value
-                     object
-                 })
 
 #' @rdname MsBackendCached
 setMethod("lengths", "MsBackendCached", function(x, use.names = FALSE) {
@@ -543,13 +504,6 @@ setMethod("mz", "MsBackendCached", function(object) {
 #' @rdname MsBackendCached
 setMethod("polarity", "MsBackendCached", function(object) {
     spectraData(object, "polarity")[, 1]
-})
-
-#' @rdname MsBackendCached
-setReplaceMethod("polarity", "MsBackendCached", function(object, value) {
-    if (is.numeric(value)) value <- as.integer(value)
-    object$polarity <- value
-    object
 })
 
 #' @rdname MsBackendCached
@@ -578,12 +532,6 @@ setMethod("rtime", "MsBackendCached", function(object) {
 })
 
 #' @rdname MsBackendCached
-setReplaceMethod("rtime", "MsBackendCached", function(object, value) {
-    object$rtime <- value
-    object
-})
-
-#' @rdname MsBackendCached
 setMethod("scanIndex", "MsBackendCached", function(object) {
     spectraData(object, "scanIndex")[, 1]
 })
@@ -591,10 +539,4 @@ setMethod("scanIndex", "MsBackendCached", function(object) {
 #' @rdname MsBackendCached
 setMethod("smoothed", "MsBackendCached", function(object) {
     spectraData(object, "smoothed")[, 1]
-})
-
-#' @rdname MsBackendCached
-setReplaceMethod("smoothed", "MsBackendCached", function(object, value) {
-    object$smoothed <- value
-    object
 })

--- a/man/MsBackendCached.Rd
+++ b/man/MsBackendCached.Rd
@@ -17,34 +17,25 @@
 \alias{show,MsBackendCached-method}
 \alias{acquisitionNum,MsBackendCached-method}
 \alias{centroided,MsBackendCached-method}
-\alias{centroided<-,MsBackendCached-method}
 \alias{collisionEnergy,MsBackendCached-method}
-\alias{collisionEnergy<-,MsBackendCached-method}
 \alias{dataOrigin,MsBackendCached-method}
-\alias{dataOrigin<-,MsBackendCached-method}
 \alias{msLevel,MsBackendCached-method}
 \alias{intensity,MsBackendCached-method}
 \alias{ionCount,MsBackendCached-method}
 \alias{isEmpty,MsBackendCached-method}
 \alias{isolationWindowLowerMz,MsBackendCached-method}
-\alias{isolationWindowLowerMz<-,MsBackendCached-method}
 \alias{isolationWindowTargetMz,MsBackendCached-method}
-\alias{isolationWindowTargetMz<-,MsBackendCached-method}
 \alias{isolationWindowUpperMz,MsBackendCached-method}
-\alias{isolationWindowUpperMz<-,MsBackendCached-method}
 \alias{lengths,MsBackendCached-method}
 \alias{mz,MsBackendCached-method}
 \alias{polarity,MsBackendCached-method}
-\alias{polarity<-,MsBackendCached-method}
 \alias{precScanNum,MsBackendCached-method}
 \alias{precursorCharge,MsBackendCached-method}
 \alias{precursorIntensity,MsBackendCached-method}
 \alias{precursorMz,MsBackendCached-method}
 \alias{rtime,MsBackendCached-method}
-\alias{rtime<-,MsBackendCached-method}
 \alias{scanIndex,MsBackendCached-method}
 \alias{smoothed,MsBackendCached-method}
-\alias{smoothed<-,MsBackendCached-method}
 \title{Base MsBackend class providing data caching mechanism}
 \usage{
 MsBackendCached()
@@ -83,15 +74,9 @@ MsBackendCached()
 
 \S4method{centroided}{MsBackendCached}(object)
 
-\S4method{centroided}{MsBackendCached}(object) <- value
-
 \S4method{collisionEnergy}{MsBackendCached}(object)
 
-\S4method{collisionEnergy}{MsBackendCached}(object) <- value
-
 \S4method{dataOrigin}{MsBackendCached}(object)
-
-\S4method{dataOrigin}{MsBackendCached}(object) <- value
 
 \S4method{msLevel}{MsBackendCached}(object)
 
@@ -103,23 +88,15 @@ MsBackendCached()
 
 \S4method{isolationWindowLowerMz}{MsBackendCached}(object)
 
-\S4method{isolationWindowLowerMz}{MsBackendCached}(object) <- value
-
 \S4method{isolationWindowTargetMz}{MsBackendCached}(object)
 
-\S4method{isolationWindowTargetMz}{MsBackendCached}(object) <- value
-
 \S4method{isolationWindowUpperMz}{MsBackendCached}(object)
-
-\S4method{isolationWindowUpperMz}{MsBackendCached}(object) <- value
 
 \S4method{lengths}{MsBackendCached}(x, use.names = FALSE)
 
 \S4method{mz}{MsBackendCached}(object)
 
 \S4method{polarity}{MsBackendCached}(object)
-
-\S4method{polarity}{MsBackendCached}(object) <- value
 
 \S4method{precScanNum}{MsBackendCached}(object)
 
@@ -131,13 +108,9 @@ MsBackendCached()
 
 \S4method{rtime}{MsBackendCached}(object)
 
-\S4method{rtime}{MsBackendCached}(object) <- value
-
 \S4method{scanIndex}{MsBackendCached}(object)
 
 \S4method{smoothed}{MsBackendCached}(object)
-
-\S4method{smoothed}{MsBackendCached}(object) <- value
 }
 \arguments{
 \item{object}{A \code{MsBackendCached} object.}

--- a/vignettes/MsBackend.Rmd
+++ b/vignettes/MsBackend.Rmd
@@ -1199,8 +1199,8 @@ be$new_var <- c("a", "b", "c")
 be$new_var
 ```
 
-Replacement methods for all *core* spectra variables can be implemented
-similarly.
+For all *core* spectra variables default replacement methods exist that use the
+`$<-` to replace values.
 
 
 ### `selectSpectraVariables()`
@@ -1269,75 +1269,6 @@ intensity(be2)
 ```
 
 
-### `centroided<-`
-
-Replace the value for the *centroided* core spectra variable. The provided data
-type **must** be a logical. We re-use the function `.sv_valid_data_type` which
-was defined above for `backendInitialize()` to check for the correct data type
-of core spectra variables.
-
-```{r}
-setReplaceMethod("centroided", "MsBackendTest", function(object, value) {
-    object@spectraVars[["centroided"]] <- value
-    .sv_valid_data_type(object@spectraVars, "centroided")
-    object
-})
-```
-
-Alternatively, we could also simply re-use the `$<-` replacement method
-above. This would make the whole code base for our backend cleaner as replacing
-or adding spectra variables would be handled in a single central function.
-
-```{r}
-setReplaceMethod("centroided", "MsBackendTest", function(object, value) {
-    object$centroided <- value
-    object
-})
-```
-
-```{r}
-centroided(be) <- c(TRUE, FALSE, TRUE)
-centroided(be)
-```
-
-
-### `collisionEnergy<-`
-
-Replace the values for the collision energy. Parameter `value` has to be of type
-`numeric`.
-
-```{r}
-setReplaceMethod("collisionEnergy", "MsBackendTest", function(object, value) {
-    object$collisionEnergy <- value
-    object
-})
-```
-
-```{r}
-collisionEnergy(be) <- c(NA_real_, 20.0, 20.0)
-collisionEnergy(be)
-```
-
-
-### `dataOrigin<-`
-
-Replace the values for the data origin spectra variable. Parameter `value` has
-to be of type `character`.
-
-```{r}
-setReplaceMethod("dataOrigin", "MsBackendTest", function(object, value) {
-    object$dataOrigin <- value
-    object
-})
-```
-
-```{r}
-dataOrigin(be)
-dataOrigin(be) <- c("unknown", "file a", "file b")
-dataOrigin(be)
-```
-
-
 ### `dataStorage<-`
 
 Replace the values for the data storage spectra variable. Parameter `value` has
@@ -1359,150 +1290,6 @@ dataStorage(be)
 dataStorage(be) <- c("", "", "")
 dataStorage(be)
 ```
-
-
-### `isolationWindowLowerMz<-`
-
-Replace the values for the *isolation window lower m/z* spectra
-variable. Parameter `value` has to be of type `numeric` (`NA_real_` missing
-values are supported, e.g. for MS1 spectra).
-
-```{r}
-setReplaceMethod(
-    "isolationWindowLowerMz", "MsBackendTest", function(object, value) {
-        object$isolationWindowLowerMz <- value
-        object
-    })
-```
-
-```{r}
-isolationWindowLowerMz(be) <- c(NA_real_, 245.3, NA_real_)
-isolationWindowLowerMz(be)
-```
-
-
-### `isolationWindowTargetMz<-`
-
-Replace the values for the *isolation window target m/z* spectra
-variable. Parameter `value` has to be of type `numeric` (`NA_real_` missing
-values are supported, e.g. for MS1 spectra).
-
-```{r}
-setReplaceMethod(
-    "isolationWindowTargetMz", "MsBackendTest", function(object, value) {
-        object$isolationWindowTargetMz <- value
-        object
-    })
-```
-
-```{r}
-isolationWindowTargetMz(be) <- c(NA_real_, 245.4, NA_real_)
-isolationWindowTargetMz(be)
-```
-
-
-### `isolationWindowUpperMz<-`
-
-Replace the values for the *isolation window upper m/z* spectra
-variable. Parameter `value` has to be of type `numeric` (`NA_real_` missing
-values are supported, e.g. for MS1 spectra).
-
-```{r}
-setReplaceMethod(
-    "isolationWindowUpperMz", "MsBackendTest", function(object, value) {
-        object$isolationWindowUpperMz <- value
-        object
-    })
-```
-
-```{r}
-isolationWindowUpperMz(be) <- c(NA_real_, 245.5, NA_real_)
-isolationWindowUpperMz(be)
-```
-
-
-### `msLevel<-`
-
-Replace the MS level of spectra in a backend. Parameter `value` has to be of
-type `integer`. Missing values (`NA_integer_`) are supported.
-
-```{r}
-setReplaceMethod("msLevel", "MsBackendTest", function(object, value) {
-    object$msLevel <- value
-    object
-})
-```
-
-```{r}
-msLevel(be)
-msLevel(be) <- c(1L, 1L, 2L)
-msLevel(be)
-```
-
-
-### `polarity<-`
-
-Replace the values for the polarity spectra variables. Parameter `value` has to
-be of type `integer` and should ideally also use the *standard* encoding `0L`
-and `1L` for negative and positive polarity (and `NA_integer` for
-missing). Thus, in our implementation we also make sure the input parameter
-contains the expected values (although this is not a strictly required).
-
-```{r}
-setReplaceMethod("polarity", "MsBackendTest", function(object, value) {
-    if (!all(value %in% c(0, 1, NA)))
-        stop("'polarity' should be encoded as 0L (negative), 1L (positive) ",
-             "with missing values being NA_integer_")
-    object$polarity <- value
-    object
-})
-```
-
-```{r}
-polarity(be) <- c(0L, 0L, 0L)
-polarity(be)
-```
-
-
-### `rtime<-`
-
-Replace the retention times for the spectra represented by the
-backend. Parameter `value` must be of type `numeric`. Also, although it is not a
-strict requirement, retention times should ideally be ordered increasingly *per
-sample* and their unit should be seconds.
-
-```{r}
-setReplaceMethod("rtime", "MsBackendTest", function(object, value) {
-    object$rtime <- value
-    object
-})
-```
-
-```{r}
-rtime(be)
-rtime(be) <- rtime(be) + 2
-rtime(be)
-```
-
-
-### `smoothed<-`
-
-Replace the spectra variable *smoothed* that indicates whether some data
-smoothing operation was performed on the spectra. Parameter `value` must be of
-type `logical`.
-
-```{r}
-setReplaceMethod("smoothed", "MsBackendTest", function(object, value) {
-    object$smoothed <- value
-    object
-})
-```
-
-```{r}
-smoothed(be) <- rep(TRUE, 3)
-smoothed(be)
-```
-
 
 ### `spectraNames<-`
 
@@ -1579,6 +1366,56 @@ The implementation for `MsBackendMzR` returns `c("dataStorage", "scanIndex")` as
 the backend needs these two spectra variables to load the MS data on-the-fly
 from the original data files.
 
+### `centroided<-`
+
+Replace the value for the *centroided* core spectra variable. The provided data
+type **must** be a logical. The default implementation of this method is:
+
+```{r}
+setReplaceMethod("centroided", "MsBackend", function(object, value) {
+    object$centroided <- value
+    object
+})
+```
+
+```{r}
+centroided(be) <- c(TRUE, FALSE, TRUE)
+centroided(be)
+```
+
+
+### `collisionEnergy<-`
+
+Replace the values for the collision energy. Parameter `value` has to be of type
+`numeric`. The default implementation of this method is:
+
+```{r}
+setReplaceMethod("collisionEnergy", "MsBackend", function(object, value) {
+    object$collisionEnergy <- value
+    object
+})
+```
+
+
+### `dataOrigin<-`
+
+Replace the values for the data origin spectra variable. Parameter `value` has
+to be of type `character`. The default implementation of this method is:
+
+```{r}
+setReplaceMethod("dataOrigin", "MsBackend", function(object, value) {
+    object$dataOrigin <- value
+    object
+})
+```
+
+```{r}
+dataOrigin(be)
+dataOrigin(be) <- c("unknown", "file a", "file b")
+dataOrigin(be)
+```
+
+
 
 ### `dropNaSpectraVariables()`
 
@@ -1605,6 +1442,69 @@ setMethod("dropNaSpectraVariables", "MsBackend", function(object) {
 })
 ```
 
+### `isolationWindowLowerMz<-`
+
+Replace the values for the *isolation window lower m/z* spectra
+variable. Parameter `value` has to be of type `numeric` (`NA_real_` missing
+values are supported, e.g. for MS1 spectra). The default implementation of this
+method is:
+
+```{r}
+setReplaceMethod(
+    "isolationWindowLowerMz", "MsBackend", function(object, value) {
+        object$isolationWindowLowerMz <- value
+        object
+    })
+```
+
+```{r}
+isolationWindowLowerMz(be) <- c(NA_real_, 245.3, NA_real_)
+isolationWindowLowerMz(be)
+```
+
+
+### `isolationWindowTargetMz<-`
+
+Replace the values for the *isolation window target m/z* spectra
+variable. Parameter `value` has to be of type `numeric` (`NA_real_` missing
+values are supported, e.g. for MS1 spectra). The default implementation of this
+method is:
+
+```{r}
+setReplaceMethod(
+    "isolationWindowTargetMz", "MsBackend", function(object, value) {
+        object$isolationWindowTargetMz <- value
+        object
+    })
+```
+
+```{r}
+isolationWindowTargetMz(be) <- c(NA_real_, 245.4, NA_real_)
+isolationWindowTargetMz(be)
+```
+
+
+### `isolationWindowUpperMz<-`
+
+Replace the values for the *isolation window upper m/z* spectra
+variable. Parameter `value` has to be of type `numeric` (`NA_real_` missing
+values are supported, e.g. for MS1 spectra). The default implementation of this
+method is:
+
+```{r}
+setReplaceMethod(
+    "isolationWindowUpperMz", "MsBackend", function(object, value) {
+        object$isolationWindowUpperMz <- value
+        object
+    })
+```
+
+```{r}
+isolationWindowUpperMz(be) <- c(NA_real_, 245.5, NA_real_)
+isolationWindowUpperMz(be)
+```
+
+
 ### `isReadOnly()`
 
 `isReadOnly()` is expected to return a `logical(1)` with either `TRUE` or
@@ -1615,6 +1515,24 @@ default implementation is shown below.
 setMethod("isReadOnly", "MsBackend", function(object) {
     object@readonly
 })
+```
+
+### `msLevel<-`
+
+Replace the MS level of spectra in a backend. Parameter `value` has to be of
+type `integer`. Missing values (`NA_integer_`) are supported.
+
+```{r}
+setReplaceMethod("msLevel", "MsBackend", function(object, value) {
+    object$msLevel <- value
+    object
+})
+```
+
+```{r}
+msLevel(be)
+msLevel(be) <- c(1L, 1L, 2L)
+msLevel(be)
 ```
 
 
@@ -1632,6 +1550,26 @@ setMethod("peaksVariables", "MsBackend", function(object) {
     c("mz", "intensity")
 })
 ```
+
+### `polarity<-`
+
+Replace the values for the polarity spectra variables. Parameter `value` has to
+be of type `integer` and should ideally also use the *standard* encoding `0L`
+and `1L` for negative and positive polarity (and `NA_integer` for
+missing).
+
+```{r}
+setReplaceMethod("polarity", "MsBackend", function(object, value) {
+    object$polarity <- value
+    object
+})
+```
+
+```{r}
+polarity(be) <- c(0L, 0L, 0L)
+polarity(be)
+```
+
 
 
 ### `uniqueMsLevels()`
@@ -1746,6 +1684,46 @@ setMethod("export", "MsBackendMzR", function(object, x, file = tempfile(),
 
 See alternatively also the `r Biocpkg("MsBackendMgf")` package for an
 implementation for the `MsBackendMgf` backend.
+
+
+### `rtime<-`
+
+Replace the retention times for the spectra represented by the
+backend. Parameter `value` must be of type `numeric`. Also, although it is not a
+strict requirement, retention times should ideally be ordered increasingly *per
+sample* and their unit should be seconds. The default implementation is:
+
+```{r}
+setReplaceMethod("rtime", "MsBackend", function(object, value) {
+    object$rtime <- value
+    object
+})
+```
+
+```{r}
+rtime(be)
+rtime(be) <- rtime(be) + 2
+rtime(be)
+```
+
+
+### `smoothed<-`
+
+Replace the spectra variable *smoothed* that indicates whether some data
+smoothing operation was performed on the spectra. Parameter `value` must be of
+type `logical`. The default implementation is:
+
+```{r}
+setReplaceMethod("smoothed", "MsBackend", function(object, value) {
+    object$smoothed <- value
+    object
+})
+```
+
+```{r}
+smoothed(be) <- rep(TRUE, 3)
+smoothed(be)
+```
 
 
 ### `split()`


### PR DESCRIPTION
This PR adds `MsBackend` default implementations for replacement methods for some core spectra variables. These replacement methods all use the `$<-` method. This should simplify implementation of new `MsBackend` classes as less methods are required to be implemented.